### PR TITLE
Use snake_case file names for Markdown documentation

### DIFF
--- a/doc/manual/Architecture.md
+++ b/doc/manual/Architecture.md
@@ -32,9 +32,9 @@ The following requirement list was the foundation for the design of the framewor
     simulation. These are "driven" in dynamic tests.
   - OpenSCENARIO (XOSC): Scenario definition, includes route definition (one file per route with
     extension .xosc)
-- **Checker:** A software module or routine that checks exactly one rule or creates statistical
-information from the route model. This can be a static or a dynamic test. For a list of possible
-tests, see parent page.
+- **Check/Checker:** A software module or routine that checks exactly one rule
+  or creates statistical information from the route model. This can be a static
+  or a dynamic test. For a list of possible tests, see parent page.
 - **Checker Bundle:** A program or framework that includes one or more checkers. CheckerBundles
   allow checks to be better structured and divided into logical groups. A CheckerBundle also
   contains the paths to OpenSCENARIO and OpenDRIVE. This makes it possible to implement a module
@@ -45,9 +45,10 @@ tests, see parent page.
     - developed in one distinct development environment/programming language
   - allow for files only be read/prepared once via parser.
   - can be started via external scripting/automation.
-- **Report or Result File** CheckerBundles write their reports in an .xqar file. See Base Library
+- **Report or Result File:** CheckerBundles write their reports in an .xqar file. See Base Library
   and File Formats for details and examples.
 - **Report Module:** Output / Transmission / Visualization Results
+- **Checker Library:** Collection of Checker Bundles and/or Report Modules for one domain.
 
 - **QC4OpenX** Framework, that:
   - feeds the route model to the individual Checker Bundles

--- a/doc/manual/Checker_Library.md
+++ b/doc/manual/Checker_Library.md
@@ -1,0 +1,87 @@
+<!---
+This Source Code Form is subject to the terms of the Mozilla
+Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+-->
+
+# Checker Library
+
+## Introduction
+
+A Checker Library is a collection of modules for one domain. Typically, it
+contains a set of checks for one standard or to test the input file for one
+specific Use Case or in one specific environment. The checks may be distributed
+in multiple Checker Bundles in the Checker Library.
+
+Each Checker Library needs to have a documentation what is included. Here we
+have to distinguish between "Checks" and "Rules". A standard specify rules,
+which are described in textual form. A check is a test implementation which
+inspects the input document to verify if it is compliant to the standard.
+
+## Rules
+
+### Rule Characteristics
+
+- Rules are atomic, easy understandable and independent of how many rules are
+  necessary in the standard.
+- A Rule should be part of a standard, as it is today in many ASAM standards.
+- Rules can come from ASAM, but also from other organizations or can be company
+  internal rules.
+- Rules may be documented in the Checker Library if they are not explicitly
+  written in the corresponding standard. The documentation can be used as a
+  proposal to the standardization project to improve the standard itself.
+
+### Rule Documentation Template
+
+If a Checker Library needs to define and document own rules, then the following
+template can be used.
+
+**Rule ID:** _Unique identifier according the [Rule UID
+Schema](Rule_Uid_Schema.md)_
+
+**Description:** _Clear textual description of the rule._
+
+**Severity:** _Indicates the rule's importance level as asserted by the
+standard (e.g., respecting the rule is mandatory or a recommendation)_
+
+**Version range:** _Information for which versions of the standard this rule applies._
+
+## Checks
+
+### Check Characteristics
+
+- A check should addresses exactly one rule. In reality, a check can address  
+  several rules, or several checks might be necessary to check a certain rule.  
+- Each check shall have a minimum of two example input files. The first
+  demonstrating a rule violation and the second showcasing a successful rule
+  validation.
+
+### Check Documentation Template
+
+**Check ID:** _The ID shall be unique within the Checker Library and
+self-explanatory as possible._
+
+**Version:** _The check itself has also a version number for identifying
+changes in the results, which are based on implementation changes._
+
+**Description:** _Clear textual description of the check._
+
+**Parameters:** _Description of the parameters of this check. For a
+well-defined standard, there should be no parameter necessary. It's often the
+case that some are needed._
+
+**Addressed Rules:** _Link to the standard and/or to rule definitions from the
+Checker Library, if no appropriate rules are explicitly written in the
+standard._
+
+**Version range:** _Information how this check is implemented for which
+versions._
+
+**Approval Information:** _Who has approved and when was this check approved.
+This may be empty if the check is not approved yet._
+
+**Metadata:** _A check may log arbitrary metadata during execution (e.g., for
+traceability). The metadata produced by a check shall be included and
+described in its documentation, (e.g., if a check logs in metadata version and
+configuration of a simulator, the checker documentation shall describe the
+content of aforementioned metadata fields)._

--- a/doc/manual/README.md
+++ b/doc/manual/README.md
@@ -13,7 +13,8 @@ with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 - [Using the Framework](Using_the_Checker_Framework.md)
 - Delivered Standard CheckerBundles
   - [SchemaChecker](SchemaChecker.md)
-- [Writing User Defined CheckerBundles or ReportModules](User_defined_modules.md)
+- [Checker Libraries containing checks from one domain](Checker_Library.md)
+- [Writing User Defined Checker Bundles or Report Modules](User_defined_modules.md)
 - [File Formats Reference](File_formats.md)
 - [C++ Base Library for Writing Own Modules](Base_Library.md)
 - [Viewer Interface for Remote Controlling a 3D Viewer from the GUI](Viewer_Interface.md)


### PR DESCRIPTION
This is for unifying/harmonizing file names and part of #7. See also https://github.com/asam-ev/qc-framework/pull/2#issuecomment-1964086256 for details, why this is done earlier than the rest.