### PR TITLE
Remove second xml library from runtime

### DIFF
--- a/runtime/runtime/runtime.py
+++ b/runtime/runtime/runtime.py
@@ -4,7 +4,6 @@
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import subprocess
-import xml.etree.ElementTree as ET
 from lxml import etree
 import sys, os
 import argparse
@@ -138,9 +137,8 @@ def run_commands_from_xml(xml_file: str, install_folder: str) -> None:
         xml_file (str): input configuration xml file
         install_folder (str): folder where executables specified in the input xml files are installed
     """
-    tree = ET.parse(xml_file)
-    root = tree.getroot()
 
+    root = etree.parse(xml_file)
     os.chdir(install_folder)
 
     print("Executable found in install directory: ", list_files_in_cwd())

--- a/runtime/tests/test_runtime.py
+++ b/runtime/tests/test_runtime.py
@@ -7,7 +7,6 @@ import pytest
 import runtime.runtime as runtime
 import os
 import subprocess
-import xml.etree.ElementTree as ET
 from lxml import etree
 from typing import List
 


### PR DESCRIPTION
**Description**

Before, two xml libraries were used for the same purpose: parsing a xml file into a python object. 
Removing xml, now only lxml is used

**How was the PR tested?**
1. Re launched test after change, ok

**Notes**
