### PR TITLE
Install cmake and gtest from standard packages

### DIFF
--- a/docker/Dockerfile.linux
+++ b/docker/Dockerfile.linux
@@ -7,8 +7,21 @@ FROM ubuntu:22.04 AS framework_builder
 
 SHELL ["/bin/bash", "-c"]
 
-RUN apt update && apt install -y g++ g++-10 git wget make build-essential && \
-    mkdir -p /app && mkdir -p /app/framework
+RUN echo "Installing Dependencies..." && \
+    apt update && apt install -y \ 
+    g++ \
+    g++-10 \
+    make \
+    build-essential \
+    cmake \
+    libgtest-dev \
+    qtbase5-dev \
+    libqt5xmlpatterns5-dev \
+    libxerces-c-dev \
+    pkg-config && \
+    echo "Dependencies installed." 
+
+RUN mkdir -p /app/framework
 
 COPY examples /app/framework/examples
 COPY include /app/framework/include
@@ -19,31 +32,7 @@ COPY doc /app/framework/doc
 COPY CMakeLists.txt /app/framework/CMakeLists.txt
 COPY version /app/framework/version
 COPY licenses /app/framework/licenses
-
-RUN mkdir dependencies && \
-    echo "Updating CMAKE..." && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.sh && \
-    apt remove cmake && \
-    apt purge --auto-remove cmake && \
-    bash cmake-3.29.3-linux-x86_64.sh --skip-license --exclude-subdir --prefix=/usr/local && \
-    echo "Installing Qt..." && \
-    apt update && apt install -y \ 
-    qtbase5-dev \
-    libqt5xmlpatterns5-dev \
-    libxerces-c-dev \
-    pkg-config && \
-    echo "Dependencies installed." 
-
-RUN echo "Installing gtest..." && \
-    git clone https://github.com/google/googletest.git -b release-1.10.0 && \
-    cd googletest && \
-    mkdir build && \
-    cd build && \
-    CXX=g++-10 cmake .. && \
-    make && \
-    make install && \
-    echo "Gtest installed."
-
+COPY runtime /app/framework/runtime
 
 RUN echo "Building framework..." && \
     cd /app/framework && \
@@ -56,7 +45,6 @@ RUN echo "Building framework..." && \
     cmake --install ./build && \
     echo "Done."
 
-COPY runtime /app/framework/runtime
 
 # Runtime stage
 FROM python:3.11.9-slim-bookworm  as runtime_test

--- a/test/function/_common/helper.h
+++ b/test/function/_common/helper.h
@@ -12,6 +12,7 @@
 
 #include "qc4openx_filesystem.h"
 #include "gtest/gtest.h"
+
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -28,6 +29,12 @@
 #include <xercesc/util/XMLException.hpp>
 #include <xercesc/util/XMLString.hpp>
 #include <xercesc/validators/schema/SchemaValidator.hpp>
+
+// Define ANSI color codes
+#define COLOR_GREEN "\033[32m"
+#define COLOR_YELLOW "\033[33m"
+#define COLOR_RESET "\033[0m"
+
 /**
  * This macro prints a formatted message during test execution.
  *
@@ -35,9 +42,7 @@
  */
 #define GTEST_PRINTF(_message)                                                                                         \
     {                                                                                                                  \
-        testing::internal::ColoredPrintf(testing::internal::COLOR_GREEN, "[          ] ");                             \
-        testing::internal::ColoredPrintf(testing::internal::COLOR_YELLOW, "%s", _message);                             \
-        testing::internal::ColoredPrintf(testing::internal::COLOR_YELLOW, "\n");                                       \
+        std::cout << COLOR_GREEN << "[          ] " << COLOR_YELLOW << _message << COLOR_YELLOW << "\n" << COLOR_RESET; \
     }
 
 /**

--- a/test/function/_common/helper.h
+++ b/test/function/_common/helper.h
@@ -9,14 +9,11 @@
 #define _HELPER_HEADER_
 
 #include <string.h>
-
 #include "qc4openx_filesystem.h"
 #include "gtest/gtest.h"
-
 #include <fstream>
 #include <iostream>
 #include <sstream>
-
 #include <string>
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/framework/XMLGrammarPoolImpl.hpp>


### PR DESCRIPTION
**Description**

- Install cmake from [jammy package](https://packages.ubuntu.com/jammy/cmake)
- Install libgtest-dev from [jammy package](https://packages.ubuntu.com/jammy/libgtest-dev)
- Small update in testing logic to remove `testing::internal::ColoredPrintf` as removed in latest gtest versions

**How was the PR tested?**
1. Launched actions on linux, OK
**Notes**
