### PR TITLE
Add rule uid to result xsd

### DIFF
--- a/doc/schema/xqar_report_format.xsd
+++ b/doc/schema/xqar_report_format.xsd
@@ -16,11 +16,7 @@ with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
   <xs:complexType name="CheckerType">
     <xs:sequence>
       <xs:element name="Issue" type="IssueType" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-    <xs:sequence>
       <xs:element name="Rule" type="RuleType" minOccurs="0" maxOccurs="unbounded" />
-    </xs:sequence>
-    <xs:sequence>
       <xs:element name="Metadata" type="MetadataType" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
     <xs:attribute name="checkerId" type="xs:string" />

--- a/doc/schema/xqar_report_format.xsd
+++ b/doc/schema/xqar_report_format.xsd
@@ -16,7 +16,7 @@ with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
   <xs:complexType name="CheckerType">
     <xs:sequence>
       <xs:element name="Issue" type="IssueType" minOccurs="0" maxOccurs="unbounded" />
-      <xs:element name="Rule" type="RuleType" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="AddressedRule" type="RuleType" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="Metadata" type="MetadataType" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
     <xs:attribute name="checkerId" type="xs:string" />

--- a/doc/schema/xqar_report_format.xsd
+++ b/doc/schema/xqar_report_format.xsd
@@ -14,12 +14,28 @@ with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
   </xs:complexType>
   
   <xs:complexType name="CheckerType">
-	<xs:sequence>
-	  <xs:element name="Issue" type="IssueType" minOccurs="0" maxOccurs="unbounded" />
-	</xs:sequence>
-	<xs:attribute name="checkerId" type="xs:string" />
-	<xs:attribute name="description" type="xs:string" />
-	<xs:attribute name="summary" type="xs:string" />
+    <xs:sequence>
+      <xs:element name="Issue" type="IssueType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:sequence>
+      <xs:element name="Rule" type="RuleType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:sequence>
+      <xs:element name="Metadata" type="MetadataType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="checkerId" type="xs:string" />
+    <xs:attribute name="description" type="xs:string" />
+    <xs:attribute name="summary" type="xs:string" />
+  </xs:complexType>
+
+  <xs:complexType name="MetadataType">
+    <xs:attribute name="key" type="xs:string" />
+    <xs:attribute name="value" type="xs:string" />
+    <xs:attribute name="description" type="xs:string" />
+  </xs:complexType>
+
+  <xs:complexType name="RuleType">
+    <xs:attribute name="ruleUID" type="xs:string" />
   </xs:complexType>
   
   <xs:complexType name="IssueType">

--- a/examples/checker_bundle_example/src/main.cpp
+++ b/examples/checker_bundle_example/src/main.cpp
@@ -140,6 +140,8 @@ void RunChecks(const cParameterContainer &inputParams)
     // Create a test checker with RuleUID and metadata
     cChecker *pExampleRuleUIDChecker = pExampleCheckerBundle->CreateChecker("exampleRuleUIDChecker", "This is a description of ruleUID checker");
     pExampleRuleUIDChecker->AddRule(new cRule("test.com::qwerty.qwerty"));
+    pExampleRuleUIDChecker->AddMetadata(new cMetadata("run date", "2024/06/06", "Date in which the checker was executed"));
+    pExampleRuleUIDChecker->AddMetadata(new cMetadata("reference project", "project01", "Name of the project that created the checker"));
 
     // Lets add a summary for the checker bundle
     unsigned int issueCount = pExampleCheckerBundle->GetIssueCount();

--- a/examples/checker_bundle_example/src/main.cpp
+++ b/examples/checker_bundle_example/src/main.cpp
@@ -14,6 +14,7 @@
 #include "common/result_format/c_result_container.h"
 #include "common/result_format/c_inertial_location.h"
 #include "common/result_format/c_locations_container.h"
+#include "common/result_format/c_rule.h"
 
 #include "common/config_format/c_configuration.h"
 #include "common/config_format/c_configuration_checker_bundle.h"
@@ -135,6 +136,10 @@ void RunChecks(const cParameterContainer &inputParams)
     std::list<cLocationsContainer*> listLoc;
     listLoc.push_back(new cLocationsContainer("inertial position", new cInertialLocation(1.0,2.0,3.0)));
     pExampleInertialChecker->AddIssue(new cIssue("This is an information from the demo usecase", INFO_LVL, listLoc));
+
+    // Create a test checker with RuleUID and metadata
+    cChecker *pExampleRuleUIDChecker = pExampleCheckerBundle->CreateChecker("exampleRuleUIDChecker", "This is a description of ruleUID checker");
+    pExampleRuleUIDChecker->AddRule(new cRule("test.com::qwerty.qwerty"));
 
     // Lets add a summary for the checker bundle
     unsigned int issueCount = pExampleCheckerBundle->GetIssueCount();

--- a/include/common/result_format/c_checker.h
+++ b/include/common/result_format/c_checker.h
@@ -12,6 +12,7 @@
 #include "../util.h"
 #include "../xml/util_xerces.h"
 #include "c_issue.h"
+#include "c_rule.h"
 #include "c_parameter_container.h"
 
 #include <list>
@@ -20,6 +21,7 @@
 // Forward declaration to avoid problems with circular dependencies (especially under Linux)
 class cCheckerBundle;
 class cIssue;
+class cRule;
 
 /*
  * Definition of a basic checker
@@ -28,6 +30,7 @@ class cChecker
 {
     friend class cCheckerBundle;
     friend class cIssue;
+    friend class cRule;
 
   public:
     static const XMLCh *TAG_CHECKER;
@@ -56,6 +59,12 @@ class cChecker
      */
     cIssue *AddIssue(cIssue *const issueToAdd);
 
+    /*
+     * Adds an rule to the checker results
+     * \param instance if the result
+     */
+    cRule *AddRule(cRule *const ruleToAdd);
+
     // Clears all issues from the container
     void Clear();
 
@@ -71,11 +80,17 @@ class cChecker
     // Counts the Issues
     unsigned int GetIssueCount();
 
+      // Counts the Rules
+    unsigned int GetRuleCount();
+
     // Updates the summary
     void UpdateSummary();
 
     // Returns the issues
     std::list<cIssue *> GetIssues();
+
+    // Returns the rules
+    std::list<cRule *> GetRules();
 
     // Processes every issue and does a defined processing
     void DoProcessing(void (*funcIzteratorPtr)(cIssue *));
@@ -173,6 +188,7 @@ class cChecker
     cCheckerBundle *m_Bundle;
 
     std::list<cIssue *> m_Issues;
+    std::list<cRule *> m_Rules;
     cParameterContainer m_Params;
 };
 

--- a/include/common/result_format/c_checker.h
+++ b/include/common/result_format/c_checker.h
@@ -13,6 +13,7 @@
 #include "../xml/util_xerces.h"
 #include "c_issue.h"
 #include "c_rule.h"
+#include "c_metadata.h"
 #include "c_parameter_container.h"
 
 #include <list>
@@ -22,6 +23,7 @@
 class cCheckerBundle;
 class cIssue;
 class cRule;
+class cMetadata;
 
 /*
  * Definition of a basic checker
@@ -31,6 +33,7 @@ class cChecker
     friend class cCheckerBundle;
     friend class cIssue;
     friend class cRule;
+    friend class cMetadata;
 
   public:
     static const XMLCh *TAG_CHECKER;
@@ -65,6 +68,12 @@ class cChecker
      */
     cRule *AddRule(cRule *const ruleToAdd);
 
+    /*
+     * Adds an metadata info to the checker results
+     * \param instance if the result
+     */
+    cMetadata *AddMetadata(cMetadata *const metadataToAdd);
+
     // Clears all issues from the container
     void Clear();
 
@@ -83,6 +92,9 @@ class cChecker
       // Counts the Rules
     unsigned int GetRuleCount();
 
+      // Counts the Rules
+    unsigned int GetMetadataCount();
+
     // Updates the summary
     void UpdateSummary();
 
@@ -91,6 +103,9 @@ class cChecker
 
     // Returns the rules
     std::list<cRule *> GetRules();
+
+    // Returns the rules
+    std::list<cMetadata *> GetMetadata();
 
     // Processes every issue and does a defined processing
     void DoProcessing(void (*funcIzteratorPtr)(cIssue *));
@@ -189,6 +204,7 @@ class cChecker
 
     std::list<cIssue *> m_Issues;
     std::list<cRule *> m_Rules;
+    std::list<cMetadata *> m_Metadata;
     cParameterContainer m_Params;
 };
 

--- a/include/common/result_format/c_metadata.h
+++ b/include/common/result_format/c_metadata.h
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef cMetadata_h__
+#define cMetadata_h__
+
+#include "string"
+#include "../xml/util_xerces.h"
+
+class cChecker;
+
+
+class cMetadata 
+{
+
+  public:
+    static const XMLCh *TAG_NAME;
+    static const XMLCh *ATTR_KEY;
+    static const XMLCh *ATTR_VALUE;
+    static const XMLCh *ATTR_DESCRIPTION;
+
+    /*
+     * Creates a new instance of cMetadata
+     * \param m_Key: metadata key
+     * \param m_Value: metadata value
+     * \param m_Description: metadata description
+     * \param description: Additional description
+     */
+    cMetadata(const std::string& input_key, const std::string& input_value,const std::string& input_description):m_Key(input_key), m_Value(input_value), m_Description(input_description) 
+    {
+    }
+
+    // Serialize this information
+    virtual XERCES_CPP_NAMESPACE::DOMElement *WriteXML(XERCES_CPP_NAMESPACE::DOMDocument *p_resultDocument);
+
+    // Unserialize this information
+    static cMetadata *ParseFromXML(XERCES_CPP_NAMESPACE::DOMNode *pXMLNode,
+                                           XERCES_CPP_NAMESPACE::DOMElement *pXMLElement, cChecker *checker);
+
+
+    // Assigns an issue to a checker
+    void AssignChecker(cChecker *checkerToAssign);
+    
+    // Returns the Key
+    std::string GetKey() const;
+    // Returns the Value
+    std::string GetValue() const;
+    // Returns the Description
+    std::string GetDescription() const;
+  
+
+  protected:
+    std::string m_Key, m_Value, m_Description;
+    cChecker *m_Checker;
+
+  private:
+    cMetadata();
+    cMetadata(const cMetadata &);
+};
+
+#endif

--- a/include/common/result_format/c_metadata.h
+++ b/include/common/result_format/c_metadata.h
@@ -1,6 +1,6 @@
 /**
  * Copyright 2024, ASAM e.V.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla
  * Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -9,13 +9,12 @@
 #ifndef cMetadata_h__
 #define cMetadata_h__
 
-#include "string"
 #include "../xml/util_xerces.h"
+#include "string"
 
 class cChecker;
 
-
-class cMetadata 
+class cMetadata
 {
 
   public:
@@ -31,7 +30,8 @@ class cMetadata
      * \param m_Description: metadata description
      * \param description: Additional description
      */
-    cMetadata(const std::string& input_key, const std::string& input_value,const std::string& input_description):m_Key(input_key), m_Value(input_value), m_Description(input_description) 
+    cMetadata(const std::string &input_key, const std::string &input_value, const std::string &input_description)
+        : m_Key(input_key), m_Value(input_value), m_Description(input_description)
     {
     }
 
@@ -40,19 +40,17 @@ class cMetadata
 
     // Unserialize this information
     static cMetadata *ParseFromXML(XERCES_CPP_NAMESPACE::DOMNode *pXMLNode,
-                                           XERCES_CPP_NAMESPACE::DOMElement *pXMLElement, cChecker *checker);
-
+                                   XERCES_CPP_NAMESPACE::DOMElement *pXMLElement, cChecker *checker);
 
     // Assigns an issue to a checker
     void AssignChecker(cChecker *checkerToAssign);
-    
+
     // Returns the Key
     std::string GetKey() const;
     // Returns the Value
     std::string GetValue() const;
     // Returns the Description
     std::string GetDescription() const;
-  
 
   protected:
     std::string m_Key, m_Value, m_Description;

--- a/include/common/result_format/c_metadata.h
+++ b/include/common/result_format/c_metadata.h
@@ -1,6 +1,6 @@
 /**
- * Copyright 2023 CARIAD SE.
- *
+ * Copyright 2024, ASAM e.V.
+ * 
  * This Source Code Form is subject to the terms of the Mozilla
  * Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/include/common/result_format/c_rule.h
+++ b/include/common/result_format/c_rule.h
@@ -1,10 +1,11 @@
 /**
- * Copyright 2023 CARIAD SE.
- *
+ * Copyright 2024, ASAM e.V.
+ * 
  * This Source Code Form is subject to the terms of the Mozilla
  * Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+
 
 #ifndef cRule_h__
 #define cRule_h__

--- a/include/common/result_format/c_rule.h
+++ b/include/common/result_format/c_rule.h
@@ -1,24 +1,23 @@
 /**
  * Copyright 2024, ASAM e.V.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla
  * Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-
 #ifndef cRule_h__
 #define cRule_h__
 
-#include "string"
 #include "../xml/util_xerces.h"
+#include "string"
 
 class cChecker;
 /*
  * Definition of additional interial location information. This can be used to debug special positions
  * in dbqa framework
  */
-class cRule 
+class cRule
 {
 
   public:
@@ -30,7 +29,7 @@ class cRule
      * \param m_RuleUID: rule id
      * \param description: Additional description
      */
-    cRule(const std::string& input_string):m_RuleUID(input_string) 
+    cRule(const std::string &input_string) : m_RuleUID(input_string)
     {
     }
 
@@ -38,16 +37,14 @@ class cRule
     virtual XERCES_CPP_NAMESPACE::DOMElement *WriteXML(XERCES_CPP_NAMESPACE::DOMDocument *p_resultDocument);
 
     // Unserialize this information
-    static cRule *ParseFromXML(XERCES_CPP_NAMESPACE::DOMNode *pXMLNode,
-                                           XERCES_CPP_NAMESPACE::DOMElement *pXMLElement, cChecker *checker);
-
+    static cRule *ParseFromXML(XERCES_CPP_NAMESPACE::DOMNode *pXMLNode, XERCES_CPP_NAMESPACE::DOMElement *pXMLElement,
+                               cChecker *checker);
 
     // Assigns an issue to a checker
     void AssignChecker(cChecker *checkerToAssign);
-    
+
     // Returns the X
     std::string GetRuleUID() const;
-  
 
   protected:
     std::string m_RuleUID;

--- a/include/common/result_format/c_rule.h
+++ b/include/common/result_format/c_rule.h
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef cRule_h__
+#define cRule_h__
+
+#include "string"
+#include "../xml/util_xerces.h"
+
+class cChecker;
+/*
+ * Definition of additional interial location information. This can be used to debug special positions
+ * in dbqa framework
+ */
+class cRule 
+{
+
+  public:
+    static const XMLCh *TAG_NAME;
+    static const XMLCh *ATTR_RULE_UID;
+
+    /*
+     * Creates a new instance of cRule
+     * \param m_RuleUID: rule id
+     * \param description: Additional description
+     */
+    cRule(const std::string& input_string):m_RuleUID(input_string) 
+    {
+    }
+
+    // Serialize this information
+    virtual XERCES_CPP_NAMESPACE::DOMElement *WriteXML(XERCES_CPP_NAMESPACE::DOMDocument *p_resultDocument);
+
+    // Unserialize this information
+    static cRule *ParseFromXML(XERCES_CPP_NAMESPACE::DOMNode *pXMLNode,
+                                           XERCES_CPP_NAMESPACE::DOMElement *pXMLElement, cChecker *checker);
+
+
+    // Assigns an issue to a checker
+    void AssignChecker(cChecker *checkerToAssign);
+    
+    // Returns the X
+    std::string GetRuleUID() const;
+  
+
+  protected:
+    std::string m_RuleUID;
+    cChecker *m_Checker;
+
+  private:
+    cRule();
+    cRule(const cRule &);
+};
+
+#endif

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(qc4openx-common STATIC
     src/config_format/c_configuration_checker_bundle.cpp
     src/config_format/c_configuration_report_module.cpp
 	src/xml/c_x_path_evaluator.cpp
+    src/result_format/c_rule.cpp
 )
 
 target_include_directories(qc4openx-common PUBLIC ${PROJECT_SOURCE_DIR}/include

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(qc4openx-common STATIC
     src/config_format/c_configuration_report_module.cpp
 	src/xml/c_x_path_evaluator.cpp
     src/result_format/c_rule.cpp
+    src/result_format/c_metadata.cpp
 )
 
 target_include_directories(qc4openx-common PUBLIC ${PROJECT_SOURCE_DIR}/include

--- a/src/common/src/result_format/c_checker.cpp
+++ b/src/common/src/result_format/c_checker.cpp
@@ -72,6 +72,16 @@ DOMElement *cChecker::WriteXML(DOMDocument *pResultDocument)
             pCheckerNode->appendChild(p_DataElement);
     }
 
+    // Add Metadatas und cCheckerSummaries
+    for (std::list<cMetadata *>::const_iterator it = m_Metadata.begin(); it != m_Metadata.end(); ++it)
+    {
+        DOMElement *p_DataElement = (*it)->WriteXML(pResultDocument);
+
+        if (nullptr != p_DataElement)
+            pCheckerNode->appendChild(p_DataElement);
+    }
+
+
     return pCheckerNode;
 }
 
@@ -194,11 +204,32 @@ cRule *cChecker::AddRule(cRule *const ruleToAdd)
     return nullptr;
 }
 
+cMetadata *cChecker::AddMetadata(cMetadata *const metadataToAdd)
+{
+    if (nullptr == m_Bundle)
+    {
+        // use runtime_error instead of exception for linux
+        throw std::runtime_error("Create the checker by using CheckerBundle::CreateChecker()!");
+    }
+    else
+    {
+        metadataToAdd->AssignChecker(this);
+        m_Metadata.push_back(metadataToAdd);
+
+        return metadataToAdd;
+    }
+    return nullptr;
+}
+
 unsigned int cChecker::GetRuleCount()
 {
     return (unsigned int)m_Rules.size();
 }
 
+unsigned int cChecker::GetMetadataCount()
+{
+    return (unsigned int)m_Metadata.size();
+}
 // Deletes all issues
 void cChecker::Clear()
 {
@@ -211,6 +242,11 @@ void cChecker::Clear()
         delete *it;
 
     m_Rules.clear();
+
+    for (std::list<cMetadata *>::iterator it = m_Metadata.begin(); it != m_Metadata.end(); it++)
+        delete *it;
+
+    m_Metadata.clear();
 }
 
 // Counts the Issues
@@ -228,6 +264,11 @@ std::list<cIssue *> cChecker::GetIssues()
 std::list<cRule *> cChecker::GetRules()
 {
     return m_Rules;
+}
+
+std::list<cMetadata *> cChecker::GetMetadata()
+{
+    return m_Metadata;
 }
 
 // Assigns a specific bundle to the checker

--- a/src/common/src/result_format/c_checker.cpp
+++ b/src/common/src/result_format/c_checker.cpp
@@ -63,6 +63,15 @@ DOMElement *cChecker::WriteXML(DOMDocument *pResultDocument)
             pCheckerNode->appendChild(p_DataElement);
     }
 
+    // Add Rules und cCheckerSummaries
+    for (std::list<cRule *>::const_iterator it = m_Rules.begin(); it != m_Rules.end(); ++it)
+    {
+        DOMElement *p_DataElement = (*it)->WriteXML(pResultDocument);
+
+        if (nullptr != p_DataElement)
+            pCheckerNode->appendChild(p_DataElement);
+    }
+
     return pCheckerNode;
 }
 
@@ -168,6 +177,28 @@ cIssue *cChecker::AddIssue(cIssue *const issueToAdd)
     return nullptr;
 }
 
+cRule *cChecker::AddRule(cRule *const ruleToAdd)
+{
+    if (nullptr == m_Bundle)
+    {
+        // use runtime_error instead of exception for linux
+        throw std::runtime_error("Create the checker by using CheckerBundle::CreateChecker()!");
+    }
+    else
+    {
+        ruleToAdd->AssignChecker(this);
+        m_Rules.push_back(ruleToAdd);
+
+        return ruleToAdd;
+    }
+    return nullptr;
+}
+
+unsigned int cChecker::GetRuleCount()
+{
+    return (unsigned int)m_Rules.size();
+}
+
 // Deletes all issues
 void cChecker::Clear()
 {
@@ -175,6 +206,11 @@ void cChecker::Clear()
         delete *it;
 
     m_Issues.clear();
+
+    for (std::list<cRule *>::iterator it = m_Rules.begin(); it != m_Rules.end(); it++)
+        delete *it;
+
+    m_Rules.clear();
 }
 
 // Counts the Issues
@@ -187,6 +223,11 @@ unsigned int cChecker::GetIssueCount()
 std::list<cIssue *> cChecker::GetIssues()
 {
     return m_Issues;
+}
+
+std::list<cRule *> cChecker::GetRules()
+{
+    return m_Rules;
 }
 
 // Assigns a specific bundle to the checker

--- a/src/common/src/result_format/c_metadata.cpp
+++ b/src/common/src/result_format/c_metadata.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#include "common/result_format/c_metadata.h"
+
+XERCES_CPP_NAMESPACE_USE
+
+const XMLCh *cMetadata::TAG_NAME = CONST_XMLCH("Metadata");
+const XMLCh *cMetadata::ATTR_KEY = CONST_XMLCH("key");
+const XMLCh *cMetadata::ATTR_VALUE = CONST_XMLCH("value");
+const XMLCh *cMetadata::ATTR_DESCRIPTION = CONST_XMLCH("description");
+
+DOMElement *cMetadata::WriteXML(DOMDocument *p_resultDocument)
+{
+    
+    DOMElement *p_DataElement = p_resultDocument->createElement(TAG_NAME);
+    XMLCh *pKey = XMLString::transcode(m_Key.c_str());
+    XMLCh *pValue = XMLString::transcode(m_Value.c_str());
+    XMLCh *pDescription = XMLString::transcode(m_Description.c_str());
+    p_DataElement->setAttribute(ATTR_KEY, pKey);
+    p_DataElement->setAttribute(ATTR_VALUE, pValue);
+    p_DataElement->setAttribute(ATTR_DESCRIPTION, pDescription);
+   
+    XMLString::release(&pKey);
+    XMLString::release(&pValue);
+    XMLString::release(&pDescription);
+
+    return p_DataElement;
+}
+
+cMetadata *cMetadata::ParseFromXML(DOMNode *, DOMElement *pXMLElement, cChecker *checker)
+{
+    std::string strKey = XMLString::transcode(pXMLElement->getAttribute(ATTR_KEY));
+    std::string strValue = XMLString::transcode(pXMLElement->getAttribute(ATTR_VALUE));
+    std::string strDescription = XMLString::transcode(pXMLElement->getAttribute(ATTR_DESCRIPTION));
+
+    cMetadata *result = new cMetadata(strKey, strValue, strDescription);
+    result->AssignChecker(checker);
+
+    return result;
+}
+
+// Returns the key
+std::string cMetadata::GetKey() const
+{
+    return m_Key;
+}
+
+// Returns the value
+std::string cMetadata::GetValue() const
+{
+    return m_Value;
+}
+
+// Returns the description
+std::string cMetadata::GetDescription() const
+{
+    return m_Description;
+}
+void cMetadata::AssignChecker(cChecker *checkerToAssign)
+{
+    m_Checker = checkerToAssign;
+}

--- a/src/common/src/result_format/c_metadata.cpp
+++ b/src/common/src/result_format/c_metadata.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright 2023 CARIAD SE.
- *
+/**
+ * Copyright 2024, ASAM e.V.
+ * 
  * This Source Code Form is subject to the terms of the Mozilla
  * Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/common/src/result_format/c_metadata.cpp
+++ b/src/common/src/result_format/c_metadata.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2024, ASAM e.V.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla
  * Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -16,7 +16,7 @@ const XMLCh *cMetadata::ATTR_DESCRIPTION = CONST_XMLCH("description");
 
 DOMElement *cMetadata::WriteXML(DOMDocument *p_resultDocument)
 {
-    
+
     DOMElement *p_DataElement = p_resultDocument->createElement(TAG_NAME);
     XMLCh *pKey = XMLString::transcode(m_Key.c_str());
     XMLCh *pValue = XMLString::transcode(m_Value.c_str());
@@ -24,7 +24,7 @@ DOMElement *cMetadata::WriteXML(DOMDocument *p_resultDocument)
     p_DataElement->setAttribute(ATTR_KEY, pKey);
     p_DataElement->setAttribute(ATTR_VALUE, pValue);
     p_DataElement->setAttribute(ATTR_DESCRIPTION, pDescription);
-   
+
     XMLString::release(&pKey);
     XMLString::release(&pValue);
     XMLString::release(&pDescription);

--- a/src/common/src/result_format/c_rule.cpp
+++ b/src/common/src/result_format/c_rule.cpp
@@ -1,6 +1,6 @@
-/*
- * Copyright 2023 CARIAD SE.
- *
+/**
+ * Copyright 2024, ASAM e.V.
+ * 
  * This Source Code Form is subject to the terms of the Mozilla
  * Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/src/common/src/result_format/c_rule.cpp
+++ b/src/common/src/result_format/c_rule.cpp
@@ -1,6 +1,6 @@
 /**
  * Copyright 2024, ASAM e.V.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla
  * Public License, v. 2.0. If a copy of the MPL was not distributed
  * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -14,11 +14,11 @@ const XMLCh *cRule::ATTR_RULE_UID = CONST_XMLCH("ruleUID");
 
 DOMElement *cRule::WriteXML(DOMDocument *p_resultDocument)
 {
-    
+
     DOMElement *p_DataElement = p_resultDocument->createElement(TAG_NAME);
     XMLCh *pRuleUID = XMLString::transcode(m_RuleUID.c_str());
     p_DataElement->setAttribute(ATTR_RULE_UID, pRuleUID);
-   
+
     XMLString::release(&pRuleUID);
 
     return p_DataElement;

--- a/src/common/src/result_format/c_rule.cpp
+++ b/src/common/src/result_format/c_rule.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#include "common/result_format/c_rule.h"
+
+XERCES_CPP_NAMESPACE_USE
+
+const XMLCh *cRule::TAG_NAME = CONST_XMLCH("AddressedRule");
+const XMLCh *cRule::ATTR_RULE_UID = CONST_XMLCH("ruleUID");
+
+DOMElement *cRule::WriteXML(DOMDocument *p_resultDocument)
+{
+    
+    DOMElement *p_DataElement = p_resultDocument->createElement(TAG_NAME);
+    XMLCh *pRuleUID = XMLString::transcode(m_RuleUID.c_str());
+    p_DataElement->setAttribute(ATTR_RULE_UID, pRuleUID);
+   
+    XMLString::release(&pRuleUID);
+
+    return p_DataElement;
+}
+
+cRule *cRule::ParseFromXML(DOMNode *, DOMElement *pXMLElement, cChecker *checker)
+{
+    std::string strRuleUID = XMLString::transcode(pXMLElement->getAttribute(ATTR_RULE_UID));
+
+    cRule *result = new cRule(strRuleUID);
+    result->AssignChecker(checker);
+
+    return result;
+}
+
+// Returns the X
+std::string cRule::GetRuleUID() const
+{
+    return m_RuleUID;
+}
+
+void cRule::AssignChecker(cChecker *checkerToAssign)
+{
+    m_Checker = checkerToAssign;
+}

--- a/test/function/examples/example_checker_bundle/src/example_checker_bundle_tester.cpp
+++ b/test/function/examples/example_checker_bundle/src/example_checker_bundle_tester.cpp
@@ -120,3 +120,24 @@ TEST_F(cTesterExampleCheckerBundle, CmdTooMuchArguments)
     TestResult nRes = ExecuteCommand(strResultMessage, MODULE_NAME, "a b");
     ASSERT_TRUE(nRes == TestResult::ERR_FAILED);
 }
+
+TEST_F(cTesterExampleCheckerBundle, CmdConfigContainsAddressedRuleAndMetadata)
+{
+    std::string strResultMessage;
+
+    std::string strConfigFilePath = strTestFilesDir + "/" + std::string(MODULE_NAME) + "_config.xml";
+    std::string strResultFilePath = strWorkingDir + "/" + std::string(MODULE_NAME) + ".xqar";
+
+    TestResult nRes = ExecuteCommand(strResultMessage, MODULE_NAME, strConfigFilePath);
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+    nRes |= CheckFileExists(strResultMessage, strResultFilePath, false);
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+
+    nRes |= XmlContainsNode(strResultFilePath, "AddressedRule");
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+    
+    nRes |= XmlContainsNode(strResultFilePath, "Metadata");
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+
+    fs::remove(strResultFilePath.c_str());
+}


### PR DESCRIPTION
**Description**

Add AddressedRule and metadata attribute to result xsd schema

From #25 , 2 out of 4 requested fields are implemented: 
- [x] (list of) addressed rule(s)
- [ ] rule version range (To be clarified if necessary,)
- [ ] approval information_(To be clarified if necessary,
- [x] meta data (To be clarified if necessary on check and/or on Checker Library level)

The remaining two fields should be already integrated in ruleUID naming conventions as indicated in #22  

Addressed Rule:
```
  <xs:element name="AddressedRule" type="RuleType" minOccurs="0" maxOccurs="unbounded" />
      ...
<xs:complexType name="RuleType">
    <xs:attribute name="ruleUID" type="xs:string" />
  </xs:complexType>
```

Metadata:
```
      <xs:element name="Metadata" type="MetadataType" minOccurs="0" maxOccurs="unbounded" />
...
 <xs:complexType name="MetadataType">
    <xs:attribute name="key" type="xs:string" />
    <xs:attribute name="value" type="xs:string" />
    <xs:attribute name="description" type="xs:string" />
  </xs:complexType>
```


**How was the PR tested?**
1. Unit-test. All unit tests passed.

Example test result with all the new fields:

```
Beginning of XML file: 
<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
<CheckerResults version="1.0.0">

  <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 2 issues" version="">
    <Checker checkerId="exampleChecker" description="This is a description" summary="">
      <Issue description="This is an information from the demo usecase" issueId="0" level="3"/>
    </Checker>
    <Checker checkerId="exampleInertialChecker" description="This is a description of inertial checker" summary="">
      <Issue description="This is an information from the demo usecase" issueId="1" level="3">
        <Locations description="inertial position">
          <InertialLocation x="1.000000" y="2.000000" z="3.000000"/>
        </Locations>
      </Issue>
    </Checker>
    <Checker checkerId="exampleRuleUIDChecker" description="This is a description of ruleUID checker" summary="">
      <AddressedRule ruleUID="test.com::qwerty.qwerty"/>
      <Metadata description="Date in which the checker was executed" key="run date" value="2024/06/06"/>
      <Metadata description="Name of the project that created the checker" key="reference project" value="project01"/>
    </Checker>
  </CheckerBundle>

</CheckerResults>

```

**Notes**

Addresses  #22  #25 
