### PR TITLE
Add checker status to represent execution status

### DIFF
--- a/doc/schema/xqar_report_format.xsd
+++ b/doc/schema/xqar_report_format.xsd
@@ -22,7 +22,15 @@ with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
         <xs:attribute name="checkerId" type="xs:string" />
         <xs:attribute name="description" type="xs:string" />
         <xs:attribute name="summary" type="xs:string" />
-        <xs:attribute name="status" type="xs:string" />
+        <xs:attribute name="status">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="completed" />
+                    <xs:enumeration value="skipped" />
+                    <xs:enumeration value="error" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="MetadataType">

--- a/doc/schema/xqar_report_format.xsd
+++ b/doc/schema/xqar_report_format.xsd
@@ -22,16 +22,17 @@ with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
         <xs:attribute name="checkerId" type="xs:string" />
         <xs:attribute name="description" type="xs:string" />
         <xs:attribute name="summary" type="xs:string" />
-        <xs:attribute name="status">
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="completed" />
-                    <xs:enumeration value="skipped" />
-                    <xs:enumeration value="error" />
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:attribute>
+        <xs:attribute name="status" type="StatusType" />
     </xs:complexType>
+
+
+    <xs:simpleType name="StatusType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="completed" />
+            <xs:enumeration value="skipped" />
+            <xs:enumeration value="error" />
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="MetadataType">
         <xs:attribute name="key" type="xs:string" />

--- a/doc/schema/xqar_report_format.xsd
+++ b/doc/schema/xqar_report_format.xsd
@@ -22,6 +22,7 @@ with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
         <xs:attribute name="checkerId" type="xs:string" />
         <xs:attribute name="description" type="xs:string" />
         <xs:attribute name="summary" type="xs:string" />
+        <xs:attribute name="status" type="xs:string" />
     </xs:complexType>
 
     <xs:complexType name="MetadataType">

--- a/examples/checker_bundle_example/src/main.cpp
+++ b/examples/checker_bundle_example/src/main.cpp
@@ -157,7 +157,7 @@ void RunChecks(const cParameterContainer &inputParams)
     // Create a test checker with Issue and RuleUID
     cChecker *pSkippedChecker = pExampleCheckerBundle->CreateChecker(
         "exampleSkippedChecker", "This is a description of checker with skipped status", "Skipped execution",
-        eStatus::SKIPPED);
+        "skipped");
 
     // Lets add a summary for the checker bundle
     unsigned int issueCount = pExampleCheckerBundle->GetIssueCount();

--- a/examples/checker_bundle_example/src/main.cpp
+++ b/examples/checker_bundle_example/src/main.cpp
@@ -154,6 +154,11 @@ void RunChecks(const cParameterContainer &inputParams)
     pExampleIssueRuleChecker->AddIssue(
         new cIssue("This is an information from the demo usecase", ERROR_LVL, "test.com::qwerty.qwerty"));
 
+    // Create a test checker with Issue and RuleUID
+    cChecker *pSkippedChecker = pExampleCheckerBundle->CreateChecker(
+        "exampleSkippedChecker", "This is a description of checker with skipped status", "Skipped execution",
+        eStatus::SKIPPED);
+
     // Lets add a summary for the checker bundle
     unsigned int issueCount = pExampleCheckerBundle->GetIssueCount();
     std::stringstream ssSummaryString;

--- a/include/common/result_format/c_checker.h
+++ b/include/common/result_format/c_checker.h
@@ -26,16 +26,6 @@ class cRule;
 class cMetadata;
 
 /*
- * Definition of issue levels
- */
-enum eStatus
-{
-    ERROR = 3,
-    SKIPPED = 2,
-    COMPLETED = 1
-};
-
-/*
  * Definition of a basic checker
  */
 class cChecker
@@ -52,8 +42,6 @@ class cChecker
     static const XMLCh *ATTR_SUMMARY;
     static const XMLCh *ATTR_STATUS;
 
-    static const std::map<eStatus, std::string> statusToString;
-    static const std::map<std::string, eStatus> stringToStatus;
     // Returns the checker id
     std::string GetCheckerID() const;
 
@@ -61,7 +49,7 @@ class cChecker
     std::string GetSummary() const;
 
     // Returns the status
-    eStatus GetStatus() const;
+    std::string GetStatus() const;
 
     // Returns the description
     std::string GetDescription() const;
@@ -73,7 +61,7 @@ class cChecker
     void SetSummary(const std::string &strSummary);
 
     // sets the status
-    void SetStatus(const eStatus &eStatus);
+    void SetStatus(const std::string &eStatus);
 
     /*
      * Adds an issue to the checker results
@@ -196,21 +184,17 @@ class cChecker
      */
     cParameterContainer *GetParamContainer();
 
-    static eStatus GetStrStatus(const std::string &inputStr);
-
-    std::string GetStatusStr() const;
-
   protected:
     // Creates a new checker instance
     cChecker(const std::string &strCheckerId, const std::string &strDescription, const std::string &strSummary,
-             const eStatus &status = eStatus::COMPLETED)
+             const std::string &strStatus)
         : m_Bundle(nullptr), m_CheckerId(strCheckerId), m_Description(strDescription), m_Summary(strSummary),
-          m_Status(status)
+          m_Status(strStatus)
     {
     }
 
     // Creates a new checker instance
-    cChecker() : m_Bundle(nullptr), m_CheckerId(""), m_Description(""), m_Summary(""), m_Status(eStatus::COMPLETED)
+    cChecker() : m_Bundle(nullptr), m_CheckerId(""), m_Description(""), m_Summary(""), m_Status("completed")
     {
     }
 
@@ -225,7 +209,7 @@ class cChecker
     std::string m_CheckerId;
     std::string m_Description;
     std::string m_Summary;
-    eStatus m_Status;
+    std::string m_Status;
     cCheckerBundle *m_Bundle;
 
     std::list<cIssue *> m_Issues;
@@ -233,7 +217,5 @@ class cChecker
     std::list<cMetadata *> m_Metadata;
     cParameterContainer m_Params;
 };
-
-std::string PrintStatus(const eStatus);
 
 #endif

--- a/include/common/result_format/c_checker.h
+++ b/include/common/result_format/c_checker.h
@@ -12,9 +12,9 @@
 #include "../util.h"
 #include "../xml/util_xerces.h"
 #include "c_issue.h"
-#include "c_rule.h"
 #include "c_metadata.h"
 #include "c_parameter_container.h"
+#include "c_rule.h"
 
 #include <list>
 #include <string>
@@ -24,6 +24,16 @@ class cCheckerBundle;
 class cIssue;
 class cRule;
 class cMetadata;
+
+/*
+ * Definition of issue levels
+ */
+enum eStatus
+{
+    ERROR = 3,
+    SKIPPED = 2,
+    COMPLETED = 1
+};
 
 /*
  * Definition of a basic checker
@@ -40,12 +50,18 @@ class cChecker
     static const XMLCh *ATTR_CHECKER_ID;
     static const XMLCh *ATTR_DESCRIPTION;
     static const XMLCh *ATTR_SUMMARY;
+    static const XMLCh *ATTR_STATUS;
 
+    static const std::map<eStatus, std::string> statusToString;
+    static const std::map<std::string, eStatus> stringToStatus;
     // Returns the checker id
     std::string GetCheckerID() const;
 
     // Returns the summary
     std::string GetSummary() const;
+
+    // Returns the status
+    eStatus GetStatus() const;
 
     // Returns the description
     std::string GetDescription() const;
@@ -55,6 +71,9 @@ class cChecker
 
     // sets the summary
     void SetSummary(const std::string &strSummary);
+
+    // sets the status
+    void SetStatus(const eStatus &eStatus);
 
     /*
      * Adds an issue to the checker results
@@ -89,10 +108,10 @@ class cChecker
     // Counts the Issues
     unsigned int GetIssueCount();
 
-      // Counts the Rules
+    // Counts the Rules
     unsigned int GetRuleCount();
 
-      // Counts the Rules
+    // Counts the Rules
     unsigned int GetMetadataCount();
 
     // Updates the summary
@@ -177,15 +196,21 @@ class cChecker
      */
     cParameterContainer *GetParamContainer();
 
+    static eStatus GetStrStatus(const std::string &inputStr);
+
+    std::string GetStatusStr() const;
+
   protected:
     // Creates a new checker instance
-    cChecker(const std::string &strCheckerId, const std::string &strDescription, const std::string &strSummary)
-        : m_Bundle(nullptr), m_CheckerId(strCheckerId), m_Description(strDescription), m_Summary(strSummary)
+    cChecker(const std::string &strCheckerId, const std::string &strDescription, const std::string &strSummary,
+             const eStatus &status = eStatus::COMPLETED)
+        : m_Bundle(nullptr), m_CheckerId(strCheckerId), m_Description(strDescription), m_Summary(strSummary),
+          m_Status(status)
     {
     }
 
     // Creates a new checker instance
-    cChecker() : m_Bundle(nullptr), m_CheckerId(""), m_Description(""), m_Summary("")
+    cChecker() : m_Bundle(nullptr), m_CheckerId(""), m_Description(""), m_Summary(""), m_Status(eStatus::COMPLETED)
     {
     }
 
@@ -200,6 +225,7 @@ class cChecker
     std::string m_CheckerId;
     std::string m_Description;
     std::string m_Summary;
+    eStatus m_Status;
     cCheckerBundle *m_Bundle;
 
     std::list<cIssue *> m_Issues;
@@ -207,5 +233,7 @@ class cChecker
     std::list<cMetadata *> m_Metadata;
     cParameterContainer m_Params;
 };
+
+std::string PrintStatus(const eStatus);
 
 #endif

--- a/include/common/result_format/c_checker_bundle.h
+++ b/include/common/result_format/c_checker_bundle.h
@@ -12,6 +12,7 @@
 #include "../util.h"
 #include "../xml/util_xerces.h"
 #include "c_parameter_container.h"
+#include "common/result_format/c_checker.h"
 #include "common/result_format/c_issue.h"
 
 // Forward declaration to avoid problems with circular dependencies (especially under Linux)
@@ -56,7 +57,7 @@ class cCheckerBundle
 
     // Adds a new checker
     cChecker *CreateChecker(const std::string &checkerId, const std::string &strDescription = "",
-                            const std::string &strSummary = "");
+                            const std::string &strSummary = "", const eStatus &inStatus = eStatus::COMPLETED);
 
     /*
      * Adds an amout of issues to the checker bundle

--- a/include/common/result_format/c_checker_bundle.h
+++ b/include/common/result_format/c_checker_bundle.h
@@ -57,7 +57,7 @@ class cCheckerBundle
 
     // Adds a new checker
     cChecker *CreateChecker(const std::string &checkerId, const std::string &strDescription = "",
-                            const std::string &strSummary = "", const eStatus &inStatus = eStatus::COMPLETED);
+                            const std::string &strSummary = "", const std::string &strStatus = "completed");
 
     /*
      * Adds an amout of issues to the checker bundle

--- a/src/common/src/result_format/c_checker.cpp
+++ b/src/common/src/result_format/c_checker.cpp
@@ -12,8 +12,14 @@ const XMLCh *cChecker::TAG_CHECKER = CONST_XMLCH("Checker");
 const XMLCh *cChecker::ATTR_CHECKER_ID = CONST_XMLCH("checkerId");
 const XMLCh *cChecker::ATTR_DESCRIPTION = CONST_XMLCH("description");
 const XMLCh *cChecker::ATTR_SUMMARY = CONST_XMLCH("summary");
+const XMLCh *cChecker::ATTR_STATUS = CONST_XMLCH("status");
 
 XERCES_CPP_NAMESPACE_USE
+
+const std::map<eStatus, std::string> cChecker::statusToString = {
+    {eStatus::COMPLETED, "completed"}, {eStatus::SKIPPED, "skipped"}, {eStatus::ERROR, "error"}};
+const std::map<std::string, eStatus> cChecker::stringToStatus = {
+    {"completed", eStatus::COMPLETED}, {"skipped", eStatus::SKIPPED}, {"error", eStatus::ERROR}};
 
 cChecker::~cChecker()
 {
@@ -33,6 +39,12 @@ std::string cChecker::GetSummary() const
     return m_Summary;
 }
 
+// Returns the status
+eStatus cChecker::GetStatus() const
+{
+    return m_Status;
+}
+
 // Returns the description
 std::string cChecker::GetDescription() const
 {
@@ -43,6 +55,12 @@ std::string cChecker::GetDescription() const
 void cChecker::SetDescription(const std::string &strDescription)
 {
     m_Description = strDescription;
+}
+
+// Sets the description
+void cChecker::SetStatus(const eStatus &eStatus)
+{
+    m_Status = eStatus;
 }
 
 // Write the xml for this issue
@@ -81,7 +99,6 @@ DOMElement *cChecker::WriteXML(DOMDocument *pResultDocument)
             pCheckerNode->appendChild(p_DataElement);
     }
 
-
     return pCheckerNode;
 }
 
@@ -96,9 +113,9 @@ cChecker *cChecker::ParseFromXML(DOMNode *pXMLNode, DOMElement *pXMLElement, cCh
     std::string strCheckerId = XMLString::transcode(pXMLElement->getAttribute(ATTR_CHECKER_ID));
     std::string strSummary = XMLString::transcode(pXMLElement->getAttribute(ATTR_SUMMARY));
     std::string strDescription = XMLString::transcode(pXMLElement->getAttribute(ATTR_DESCRIPTION));
+    std::string strStatus = XMLString::transcode(pXMLElement->getAttribute(ATTR_STATUS));
 
-    cChecker *pChecker = new cChecker(strCheckerId, strDescription, strSummary);
-
+    cChecker *pChecker = new cChecker(strCheckerId, strDescription, strSummary, GetStrStatus(strStatus));
     pChecker->AssignCheckerBundle(checkerBundle);
 
     DOMNodeList *pIssueChildList = pXMLNode->getChildNodes();
@@ -135,6 +152,27 @@ cChecker *cChecker::ParseFromXML(DOMNode *pXMLNode, DOMElement *pXMLElement, cCh
     return pChecker;
 }
 
+// Returns the issue level
+eStatus cChecker::GetStrStatus(const std::string &inputStr)
+{
+    const std::map<std::string, eStatus>::const_iterator pos = stringToStatus.find(inputStr);
+
+    if (pos != stringToStatus.end())
+        return pos->second;
+
+    return eStatus::ERROR;
+}
+
+// Returns the issue level
+std::string cChecker::GetStatusStr() const
+{
+    const std::map<eStatus, std::string>::const_iterator pos = statusToString.find(m_Status);
+
+    if (pos != statusToString.end())
+        return pos->second;
+
+    return std::string("Unknown");
+}
 DOMElement *cChecker::CreateNode(DOMDocument *pDOMDocResultDocument)
 {
     DOMElement *pBundleSummary = pDOMDocResultDocument->createElement(TAG_CHECKER);
@@ -142,14 +180,17 @@ DOMElement *cChecker::CreateNode(DOMDocument *pDOMDocResultDocument)
     XMLCh *pCheckerId = XMLString::transcode(m_CheckerId.c_str());
     XMLCh *pDescription = XMLString::transcode(m_Description.c_str());
     XMLCh *pSummary = XMLString::transcode(m_Summary.c_str());
+    XMLCh *pStatus = XMLString::transcode(GetStatusStr().c_str());
 
     pBundleSummary->setAttribute(ATTR_CHECKER_ID, pCheckerId);
     pBundleSummary->setAttribute(ATTR_DESCRIPTION, pDescription);
     pBundleSummary->setAttribute(ATTR_SUMMARY, pSummary);
+    pBundleSummary->setAttribute(ATTR_STATUS, pStatus);
 
     XMLString::release(&pCheckerId);
     XMLString::release(&pDescription);
     XMLString::release(&pSummary);
+    XMLString::release(&pStatus);
 
     return pBundleSummary;
 }
@@ -402,4 +443,22 @@ unsigned long long cChecker::NextFreeId() const
             return newId;
         }
     }
+}
+
+std::string PrintStatus(const eStatus status)
+{
+    std::string retval;
+
+    switch (status)
+    {
+    case COMPLETED:
+        retval = "completed";
+        break;
+    case SKIPPED:
+        retval = "skipped";
+        break;
+    default:
+        retval = "error";
+    }
+    return retval;
 }

--- a/src/common/src/result_format/c_checker.cpp
+++ b/src/common/src/result_format/c_checker.cpp
@@ -16,11 +16,6 @@ const XMLCh *cChecker::ATTR_STATUS = CONST_XMLCH("status");
 
 XERCES_CPP_NAMESPACE_USE
 
-const std::map<eStatus, std::string> cChecker::statusToString = {
-    {eStatus::COMPLETED, "completed"}, {eStatus::SKIPPED, "skipped"}, {eStatus::ERROR, "error"}};
-const std::map<std::string, eStatus> cChecker::stringToStatus = {
-    {"completed", eStatus::COMPLETED}, {"skipped", eStatus::SKIPPED}, {"error", eStatus::ERROR}};
-
 cChecker::~cChecker()
 {
     Clear();
@@ -40,7 +35,7 @@ std::string cChecker::GetSummary() const
 }
 
 // Returns the status
-eStatus cChecker::GetStatus() const
+std::string cChecker::GetStatus() const
 {
     return m_Status;
 }
@@ -58,7 +53,7 @@ void cChecker::SetDescription(const std::string &strDescription)
 }
 
 // Sets the description
-void cChecker::SetStatus(const eStatus &eStatus)
+void cChecker::SetStatus(const std::string &eStatus)
 {
     m_Status = eStatus;
 }
@@ -115,7 +110,7 @@ cChecker *cChecker::ParseFromXML(DOMNode *pXMLNode, DOMElement *pXMLElement, cCh
     std::string strDescription = XMLString::transcode(pXMLElement->getAttribute(ATTR_DESCRIPTION));
     std::string strStatus = XMLString::transcode(pXMLElement->getAttribute(ATTR_STATUS));
 
-    cChecker *pChecker = new cChecker(strCheckerId, strDescription, strSummary, GetStrStatus(strStatus));
+    cChecker *pChecker = new cChecker(strCheckerId, strDescription, strSummary, strStatus);
     pChecker->AssignCheckerBundle(checkerBundle);
 
     DOMNodeList *pIssueChildList = pXMLNode->getChildNodes();
@@ -152,27 +147,6 @@ cChecker *cChecker::ParseFromXML(DOMNode *pXMLNode, DOMElement *pXMLElement, cCh
     return pChecker;
 }
 
-// Returns the issue level
-eStatus cChecker::GetStrStatus(const std::string &inputStr)
-{
-    const std::map<std::string, eStatus>::const_iterator pos = stringToStatus.find(inputStr);
-
-    if (pos != stringToStatus.end())
-        return pos->second;
-
-    return eStatus::ERROR;
-}
-
-// Returns the issue level
-std::string cChecker::GetStatusStr() const
-{
-    const std::map<eStatus, std::string>::const_iterator pos = statusToString.find(m_Status);
-
-    if (pos != statusToString.end())
-        return pos->second;
-
-    return std::string("Unknown");
-}
 DOMElement *cChecker::CreateNode(DOMDocument *pDOMDocResultDocument)
 {
     DOMElement *pBundleSummary = pDOMDocResultDocument->createElement(TAG_CHECKER);
@@ -180,7 +154,7 @@ DOMElement *cChecker::CreateNode(DOMDocument *pDOMDocResultDocument)
     XMLCh *pCheckerId = XMLString::transcode(m_CheckerId.c_str());
     XMLCh *pDescription = XMLString::transcode(m_Description.c_str());
     XMLCh *pSummary = XMLString::transcode(m_Summary.c_str());
-    XMLCh *pStatus = XMLString::transcode(GetStatusStr().c_str());
+    XMLCh *pStatus = XMLString::transcode(m_Status.c_str());
 
     pBundleSummary->setAttribute(ATTR_CHECKER_ID, pCheckerId);
     pBundleSummary->setAttribute(ATTR_DESCRIPTION, pDescription);
@@ -443,22 +417,4 @@ unsigned long long cChecker::NextFreeId() const
             return newId;
         }
     }
-}
-
-std::string PrintStatus(const eStatus status)
-{
-    std::string retval;
-
-    switch (status)
-    {
-    case COMPLETED:
-        retval = "completed";
-        break;
-    case SKIPPED:
-        retval = "skipped";
-        break;
-    default:
-        retval = "error";
-    }
-    return retval;
 }

--- a/src/common/src/result_format/c_checker_bundle.cpp
+++ b/src/common/src/result_format/c_checker_bundle.cpp
@@ -147,15 +147,15 @@ cChecker *cCheckerBundle::CreateChecker(cChecker *newChecker)
 
 // Adds a new checker
 cChecker *cCheckerBundle::CreateChecker(const std::string &checkerId, const std::string &strDescription,
-                                        const std::string &strSummary)
+                                        const std::string &strSummary, const eStatus &inStatus)
 {
-    return CreateChecker(new cChecker(checkerId, strDescription, strSummary));
+    return CreateChecker(new cChecker(checkerId, strDescription, strSummary, inStatus));
 }
 
 cChecker *cCheckerBundle::CreateCheckerWithIssues(const std::string &strCheckerId, const std::string &strDescription,
                                                   eIssueLevel issueLevel, std::map<std::string, std::string> m_Issues)
 {
-    cChecker *pChecker = new cChecker(strCheckerId, strDescription, "");
+    cChecker *pChecker = new cChecker(strCheckerId, strDescription, "", eStatus::COMPLETED);
     CreateChecker(pChecker);
 
     for (std::map<std::string, std::string>::const_iterator it = m_Issues.cbegin(); it != m_Issues.cend(); it++)

--- a/src/common/src/result_format/c_checker_bundle.cpp
+++ b/src/common/src/result_format/c_checker_bundle.cpp
@@ -155,7 +155,7 @@ cChecker *cCheckerBundle::CreateChecker(const std::string &checkerId, const std:
 cChecker *cCheckerBundle::CreateCheckerWithIssues(const std::string &strCheckerId, const std::string &strDescription,
                                                   eIssueLevel issueLevel, std::map<std::string, std::string> m_Issues)
 {
-    cChecker *pChecker = new cChecker(strCheckerId, strDescription, "", "");
+    cChecker *pChecker = new cChecker(strCheckerId, strDescription, "", "completed");
     CreateChecker(pChecker);
 
     for (std::map<std::string, std::string>::const_iterator it = m_Issues.cbegin(); it != m_Issues.cend(); it++)

--- a/src/common/src/result_format/c_checker_bundle.cpp
+++ b/src/common/src/result_format/c_checker_bundle.cpp
@@ -147,15 +147,15 @@ cChecker *cCheckerBundle::CreateChecker(cChecker *newChecker)
 
 // Adds a new checker
 cChecker *cCheckerBundle::CreateChecker(const std::string &checkerId, const std::string &strDescription,
-                                        const std::string &strSummary, const eStatus &inStatus)
+                                        const std::string &strSummary, const std::string &strStatus)
 {
-    return CreateChecker(new cChecker(checkerId, strDescription, strSummary, inStatus));
+    return CreateChecker(new cChecker(checkerId, strDescription, strSummary, strStatus));
 }
 
 cChecker *cCheckerBundle::CreateCheckerWithIssues(const std::string &strCheckerId, const std::string &strDescription,
                                                   eIssueLevel issueLevel, std::map<std::string, std::string> m_Issues)
 {
-    cChecker *pChecker = new cChecker(strCheckerId, strDescription, "", eStatus::COMPLETED);
+    cChecker *pChecker = new cChecker(strCheckerId, strDescription, "", "");
     CreateChecker(pChecker);
 
     for (std::map<std::string, std::string>::const_iterator it = m_Issues.cbegin(); it != m_Issues.cend(); it++)

--- a/test/function/examples/example_checker_bundle/files/result_file_ok.xqar
+++ b/test/function/examples/example_checker_bundle/files/result_file_ok.xqar
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 3 issues" version="">
+    <Checker checkerId="exampleChecker" description="This is a description" status="completed" summary="">
+      <Issue description="This is an information from the demo usecase" issueId="0" level="3" ruleUID=""/>
+    </Checker>
+    <Checker checkerId="exampleInertialChecker" description="This is a description of inertial checker" status="completed" summary="">
+      <Issue description="This is an information from the demo usecase" issueId="1" level="3" ruleUID="">
+        <Locations description="inertial position">
+          <InertialLocation x="1.000000" y="2.000000" z="3.000000"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker checkerId="exampleRuleUIDChecker" description="This is a description of ruleUID checker" status="completed" summary="">
+      <AddressedRule ruleUID="test.com::qwerty.qwerty"/>
+      <Metadata description="Date in which the checker was executed" key="run date" value="2024/06/06"/>
+      <Metadata description="Name of the project that created the checker" key="reference project" value="project01"/>
+    </Checker>
+    <Checker checkerId="exampleIssueRuleChecker" description="This is a description of checker with issue and the involved ruleUID" status="completed" summary="">
+      <Issue description="This is an information from the demo usecase" issueId="2" level="1" ruleUID="test.com::qwerty.qwerty"/>
+    </Checker>
+    <Checker checkerId="exampleSkippedChecker" description="This is a description of checker with skipped status" status="skipped" summary="Skipped execution"/>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/test/function/examples/example_checker_bundle/files/result_file_wrong_status.xqar
+++ b/test/function/examples/example_checker_bundle/files/result_file_wrong_status.xqar
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 3 issues" version="">
+    <Checker checkerId="exampleSkippedChecker" description="This is a description of checker with skipped status" status="success" summary="Skipped execution"/>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/test/function/examples/example_checker_bundle/src/example_checker_bundle_tester.cpp
+++ b/test/function/examples/example_checker_bundle/src/example_checker_bundle_tester.cpp
@@ -141,3 +141,33 @@ TEST_F(cTesterExampleCheckerBundle, CmdConfigContainsAddressedRuleAndMetadata)
 
     fs::remove(strResultFilePath.c_str());
 }
+
+TEST_F(cTesterExampleCheckerBundle, TestFileWrongStatus)
+{
+    std::string strResultMessage;
+
+    std::string strFilePath = strTestFilesDir + "/result_file_wrong_status.xqar";
+    std::string strXsdFilePath = strTestFilesDir + "/../../../doc/schema/xqar_report_format.xsd";
+
+    TestResult nRes = CheckFileExists(strResultMessage, strFilePath, false);
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+    nRes |= CheckFileExists(strResultMessage, strXsdFilePath, false);
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+    nRes |= ValidateXmlSchema(strFilePath, strXsdFilePath);
+    ASSERT_TRUE_EXT(nRes != TestResult::ERR_NOERROR, strResultMessage.c_str());
+}
+
+TEST_F(cTesterExampleCheckerBundle, TestFileOK)
+{
+    std::string strResultMessage;
+
+    std::string strFilePath = strTestFilesDir + "/result_file_ok.xqar";
+    std::string strXsdFilePath = strTestFilesDir + "/../../../doc/schema/xqar_report_format.xsd";
+
+    TestResult nRes = CheckFileExists(strResultMessage, strFilePath, false);
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+    nRes |= CheckFileExists(strResultMessage, strXsdFilePath, false);
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+    nRes |= ValidateXmlSchema(strFilePath, strXsdFilePath);
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+}


### PR DESCRIPTION
**Description**

Addressing #45 , Add status to checker xsd schema and c++ class
Possible values are: COMPLETED, SKIPPED and ERROR

**How was the PR tested?**
1. Execute tests, All OK

new unit test correctly executed, e.g. expected to fail

```
[ RUN      ] cTesterExampleCheckerBundle.TestFileWrongStatus
Beginning of XML file: 
<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
<CheckerResults version="1.0.0">

  <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 3 issues" version="">
    <Checker checkerId="exampleSkippedChecker" description="This is a description of checker with skipped status" status="success" summary="Skipped execution"/>
  </CheckerBundle>

</CheckerResults>

Error: value 'success' not in enumeration
[       OK ] cTesterExampleCheckerBundle.TestFileWrongStatus (0 ms)

```

**Notes**
