### PR TITLE
Add violated and checked rule list in text report

### DIFF
--- a/runtime/tests/test_data/3steps_config.xml
+++ b/runtime/tests/test_data/3steps_config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<Config>
+
+  <Param name="XodrFile" value="../stimuli/xodr_examples/three_connected_roads_with_steps.xodr"/>
+
+  <CheckerBundle application="DemoCheckerBundle">
+    <Param name="strResultFile" value="DemoCheckerBundle.xqar"/>
+    <Checker checkerId="exampleChecker" maxLevel="1" minLevel="3"/>
+  </CheckerBundle>
+
+  <ReportModule application="TextReport">
+    <Param name="strInputFile" value="Result.xqar"/>
+    <Param name="strReportFile" value="Report.txt"/>
+  </ReportModule>
+
+</Config>

--- a/runtime/tests/test_runtime.py
+++ b/runtime/tests/test_runtime.py
@@ -57,6 +57,7 @@ def check_node_exists(xml_file: str, node_name: str) -> bool:
 
 def test_runtime_execution():
 
+    start_wd = os.getcwd()
     install_dir = os.path.join("..", "build", "bin")
     os.chdir(install_dir)
 
@@ -93,3 +94,45 @@ def test_runtime_execution():
     # Check that at least one node called "Issue" is present in the result
     node_name = "Issue"
     assert check_node_exists(result_file, node_name)
+
+    os.chdir(start_wd)
+
+
+def test_3steps_config():
+
+    start_wd = os.getcwd()
+    install_dir = os.path.join("..", "build", "bin")
+    os.chdir(install_dir)
+
+    config_xml = os.path.join(
+        "..", "..", "runtime", "tests", "test_data", "3steps_config.xml"
+    )
+
+    schema_dir = os.path.join("..", "..", "doc", "schema")
+    runtime_script = os.path.join("..", "..", "runtime", "runtime", "runtime.py")
+
+    process = subprocess.Popen(
+        f"python3 {runtime_script} --config={config_xml} --install_dir={os.getcwd()} --schema_dir={schema_dir}",
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=os.getcwd(),
+    )
+    stdout, stderr = process.communicate()
+    exit_code = process.returncode
+    if exit_code == 0:
+        print("Command executed successfully.")
+        print("Output:")
+        print(stdout.decode())
+    else:
+        print("Error occurred while executing the command.")
+        print("Error message:")
+        print(stderr.decode())
+    # Check that result file is correctly generated
+    result_file = os.path.join("Result.xqar")
+    assert os.path.isfile(result_file)
+    # Check that report txt file is correctly generated
+    result_file = os.path.join("Report.txt")
+    assert os.path.isfile(result_file)
+
+    os.chdir(start_wd)

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -283,13 +283,13 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
 
         ss << "Addressed vs Violated rules report \n\n";
 
-        ss << "\nTotal number of addressed rules: \t" << addressed_rules.size();
+        ss << "\nTotal number of addressed rules:   " << addressed_rules.size();
         for (const auto &str : addressed_rules)
         {
             ss << "\n\t-> Addressed RuleUID: " << str << "\n";
         }
 
-        ss << "\nTotal number of violated rules: \t" << violated_rules.size();
+        ss << "\nTotal number of violated rules:    " << violated_rules.size();
         for (const auto &str : violated_rules)
         {
             ss << "\n\t-> Violated RuleUID: " << str << "\n";

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -178,7 +178,7 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
     std::list<cIssue *> issues;
     std::list<cRule *> rules;
     std::set<std::string> violated_rules;
-    std::set<std::string> checked_rules;
+    std::set<std::string> addressed_rules;
 
     if (outFile.is_open())
     {
@@ -273,7 +273,7 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
                 {
                     if ((*it_Rule)->GetRuleUID() != "")
                     {
-                        checked_rules.insert((*it_Rule)->GetRuleUID());
+                        addressed_rules.insert((*it_Rule)->GetRuleUID());
                     }
                 }
             }
@@ -283,13 +283,13 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
 
         ss << "Addressed vs Violated rules report \n\n";
 
-        ss << "\nTotal number of addressed rules:\t" << checked_rules.size();
-        for (const auto &str : checked_rules)
+        ss << "\nTotal number of addressed rules: \t" << addressed_rules.size();
+        for (const auto &str : addressed_rules)
         {
             ss << "\n\t-> Addressed RuleUID: " << str << "\n";
         }
 
-        ss << "\nTotal number of violated rules:\t" << violated_rules.size();
+        ss << "\nTotal number of violated rules: \t" << violated_rules.size();
         for (const auto &str : violated_rules)
         {
             ss << "\n\t-> Violated RuleUID: " << str << "\n";

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -281,12 +281,12 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
             ss << "\n" << BASIC_SEPARATOR_LINE << "\n";
         }
 
-        ss << "Checked vs Violated rules report \n\n";
+        ss << "Addressed vs Violated rules report \n\n";
 
-        ss << "\nTotal number of checked rules:\t" << checked_rules.size();
+        ss << "\nTotal number of addressed rules:\t" << checked_rules.size();
         for (const auto &str : checked_rules)
         {
-            ss << "\n\t-> Checked RuleUID: " << str << "\n";
+            ss << "\n\t-> Addressed RuleUID: " << str << "\n";
         }
 
         ss << "\nTotal number of violated rules:\t" << violated_rules.size();

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -281,17 +281,21 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
             ss << "\n" << BASIC_SEPARATOR_LINE << "\n";
         }
 
-        ss << "\n    Total number of checked rules:        " << checked_rules.size();
+        ss << "Checked vs Violated rules report \n\n";
+
+        ss << "\nTotal number of checked rules:\t" << checked_rules.size();
         for (const auto &str : checked_rules)
         {
-            ss << "\n     ->  " << str << "\n";
+            ss << "\n\t-> Checked RuleUID: " << str << "\n";
         }
 
-        ss << "\n    Total number of violated rules:        " << violated_rules.size();
+        ss << "\nTotal number of violated rules:\t" << violated_rules.size();
         for (const auto &str : violated_rules)
         {
-            ss << "\n     ->  " << str << "\n";
+            ss << "\n\t-> Violated RuleUID: " << str << "\n";
         }
+
+        ss << "\n" << BASIC_SEPARATOR_LINE << "\n";
 
         outFile << ss.rdbuf();
         outFile.close();


### PR DESCRIPTION
**Description**

Addressing #26 -> Add to text report module the list of checked and violated ruleUID

Also adding a new test for the runtime in which DemoCheckerBundle+ResultPooling+TextReport is executed

**How was the PR tested?**
1. Previous and new test executed -> OK

Example output

```
====================================================================================================
QC4OpenX - Pooled results
====================================================================================================


====================================================================================================
    CheckerBundle:  DemoCheckerBundle
    Build date:     
    Build version:  
    Description:    
    Summary:        Found 3 issues

    Checker:        exampleChecker
    Description:    This is a description
    Summary:        
        Info:       #0: This is an information from the demo usecase

    Checker:        exampleInertialChecker
    Description:    This is a description of inertial checker
    Summary:        
        Info:       #1: This is an information from the demo usecase
                    inertial position
                       Location: x=1 y=2 z=3

    Checker:        exampleIssueRuleChecker
    Description:    This is a description of checker with issue and the involved ruleUID
    Summary:        
        Error:      #2: This is an information from the demo usecase

====================================================================================================

Addressed vs Violated rules report 


Total number of addressed rules: 	0
Total number of violated rules: 	1
	-> Violated RuleUID: test.com::qwerty.qwerty

====================================================================================================



```

**Notes**

Current xsd has:

- `AddressedRule` , containing all ruleUID each checker is focused on
- `Issue` attribute, with its `ruleUID`,  there to represent the specific rule each Issue is about

Given this, there could be the chance that in a report file there are `ruleUID` present in the issue attribute, but not in the `addressedRule`
Something like "I am addressing rule A,B,C, in my findings rule D gets violated"
