### PR TITLE
Support domain specific info in the result xsd schema

### DIFF
--- a/doc/schema/xqar_report_format.xsd
+++ b/doc/schema/xqar_report_format.xsd
@@ -47,11 +47,20 @@ with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
     <xs:complexType name="IssueType">
         <xs:sequence>
             <xs:element name="Locations" type="LocationsType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="DomainSpecificInfo" type="DomainSpecificInfoType" minOccurs="0"
+                maxOccurs="unbounded" />
+
         </xs:sequence>
         <xs:attribute name="issueId" type="xs:string" />
         <xs:attribute name="description" type="xs:string" />
         <xs:attribute name="level" type="xs:string" />
         <xs:attribute name="ruleUID" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="DomainSpecificInfoType">
+        <xs:sequence>
+            <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="LocationsType">

--- a/doc/schema/xqar_report_format.xsd
+++ b/doc/schema/xqar_report_format.xsd
@@ -61,6 +61,7 @@ with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
         <xs:sequence>
             <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
+        <xs:attribute name="name" type="xs:string" />
     </xs:complexType>
 
     <xs:complexType name="LocationsType">

--- a/include/common/result_format/c_domain_specific_info.h
+++ b/include/common/result_format/c_domain_specific_info.h
@@ -26,8 +26,8 @@ class cDomainSpecificInfo
     static const XMLCh *ATTR_NAME;
     /*
      * Creates a new instance of cDomainSpecificInfo
-     * \param m_AnyDoc: rule id
-     * \param description: Additional description
+     * \param inputRoot: xml tree root for the initialization
+     * \param name: Name of the tag
      */
     cDomainSpecificInfo(DOMElement *inputRoot, const std::string &name = "") : m_Root(inputRoot), m_Name(name)
     {

--- a/include/common/result_format/c_domain_specific_info.h
+++ b/include/common/result_format/c_domain_specific_info.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2024, ASAM e.V.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef cDomainSpecificInfo_h__
+#define cDomainSpecificInfo_h__
+
+#include "../xml/util_xerces.h"
+#include "string"
+#include <xercesc/dom/DOMElement.hpp>
+
+XERCES_CPP_NAMESPACE_USE
+
+/*
+ * Definition of domain specific information. This can be used to represent custom info in result file
+ */
+class cDomainSpecificInfo
+{
+
+  public:
+    static const XMLCh *TAG_DOMAIN_SPECIFIC_INFO;
+    static const XMLCh *ATTR_NAME;
+    /*
+     * Creates a new instance of cDomainSpecificInfo
+     * \param m_AnyDoc: rule id
+     * \param description: Additional description
+     */
+    cDomainSpecificInfo(DOMElement *inputRoot, const std::string &name = "") : m_Root(inputRoot), m_Name(name)
+    {
+    }
+
+    // Serialize this information
+    virtual XERCES_CPP_NAMESPACE::DOMElement *WriteXML(XERCES_CPP_NAMESPACE::DOMDocument *p_resultDocument);
+
+    // Unserialize this information
+    static cDomainSpecificInfo *ParseFromXML(XERCES_CPP_NAMESPACE::DOMNode *pXMLNode,
+                                             XERCES_CPP_NAMESPACE::DOMElement *pXMLElement);
+
+    // Returns the root
+    DOMElement *GetRoot() const;
+    // Returns the name
+    std::string GetName() const;
+
+  protected:
+    DOMElement *m_Root;
+    std::string m_Name;
+
+  private:
+    cDomainSpecificInfo();
+    cDomainSpecificInfo(const cDomainSpecificInfo &);
+};
+
+#endif

--- a/include/common/result_format/c_domain_specific_info.h
+++ b/include/common/result_format/c_domain_specific_info.h
@@ -29,8 +29,14 @@ class cDomainSpecificInfo
      * \param inputRoot: xml tree root for the initialization
      * \param name: Name of the tag
      */
-    cDomainSpecificInfo(DOMElement *inputRoot, const std::string &name = "") : m_Root(inputRoot), m_Name(name)
+    cDomainSpecificInfo(DOMElement *inputRoot, const std::string &name = "") : m_Name(name)
     {
+        // Get the original document's implementation
+        DOMImplementation *impl = inputRoot->getOwnerDocument()->getImplementation();
+        // Create a new document to own the cloned element
+        m_Doc = impl->createDocument();
+        // Import the element into the new document, effectively cloning it
+        m_Root = dynamic_cast<DOMElement *>(m_Doc->importNode(inputRoot, true));
     }
 
     // Serialize this information
@@ -44,9 +50,13 @@ class cDomainSpecificInfo
     DOMElement *GetRoot() const;
     // Returns the name
     std::string GetName() const;
+    DOMDocument *GetDoc() const;
+
+    ~cDomainSpecificInfo();
 
   protected:
     DOMElement *m_Root;
+    DOMDocument *m_Doc;
     std::string m_Name;
 
   private:

--- a/include/common/result_format/c_issue.h
+++ b/include/common/result_format/c_issue.h
@@ -19,6 +19,7 @@
 
 class cChecker;
 class cLocationsContainer;
+class cDomainSpecificInfo;
 
 /*
  * Definition of issue levels
@@ -59,6 +60,9 @@ class cIssue : public IResult
      */
     cIssue(const std::string &description, eIssueLevel infoLvl, std::list<cLocationsContainer *> listLoc);
 
+    cIssue(const std::string &description, eIssueLevel infoLvl,
+           std::list<cDomainSpecificInfo *> listDomainSpecificInfo);
+
     cIssue(const std::string &description, eIssueLevel infoLvl, const std::string &ruleUID,
            std::list<cLocationsContainer *> listLoc);
 
@@ -67,8 +71,14 @@ class cIssue : public IResult
     // Adds extendesd information to this issue
     void AddLocationsContainer(cLocationsContainer *locationsContainer);
 
+    // Adds domain specific info to this issue
+    void AddDomainSpecificInfo(cDomainSpecificInfo *domainSpecificInfo);
+
     // Adds extendesd information to this issue
     void AddLocationsContainer(std::list<cLocationsContainer *> listLoc);
+
+    // Adds domain specific info to this issue
+    void AddDomainSpecificInfo(std::list<cDomainSpecificInfo *> listDomainSpecificInfo);
 
     // Write the xml for this issue
     virtual DOMElement *WriteXML(XERCES_CPP_NAMESPACE::DOMDocument *p_resultDocument);
@@ -121,8 +131,13 @@ class cIssue : public IResult
     // Returns true if this issue has location containers
     bool HasLocations() const;
 
+    bool HasDomainSpecificInfo() const;
+
     // Returns all extended informations
     std::list<cLocationsContainer *> GetLocationsContainer() const;
+
+    // Returns all domain specific info
+    std::list<cDomainSpecificInfo *> GetDomainSpecificInfo() const;
 
     // Returns the checker this issue belongs to
     cChecker *GetChecker() const;
@@ -144,6 +159,7 @@ class cIssue : public IResult
     cChecker *m_Checker;
 
     std::list<cLocationsContainer *> m_Locations;
+    std::list<cDomainSpecificInfo *> m_DomainSpecificInfo;
 };
 
 std::string PrintIssueLevel(const eIssueLevel);

--- a/include/common/result_format/c_issue.h
+++ b/include/common/result_format/c_issue.h
@@ -52,7 +52,7 @@ class cIssue : public IResult
      *
      */
     cIssue(const std::string &description, eIssueLevel infoLvl, const std::string &ruleUID = "",
-           cLocationsContainer *locationsContainer = nullptr);
+           cLocationsContainer *locationsContainer = nullptr, cDomainSpecificInfo *domainSpecificInfo = nullptr);
 
     /*
      * Creates a new Issue
@@ -88,6 +88,8 @@ class cIssue : public IResult
 
     // Returns th count of locations
     std::size_t GetLocationsCount() const;
+
+    size_t GetDomainSpecificCount() const;
 
     // Assigns an issue to a checker
     void AssignChecker(cChecker *checkerToAssign);

--- a/runtime/tests/test_runtime.py
+++ b/runtime/tests/test_runtime.py
@@ -57,7 +57,7 @@ def check_node_exists(xml_file: str, node_name: str) -> bool:
 
 def test_runtime_execution():
 
-    start_wd = os.getcwd()
+    # start_wd = os.getcwd()
     install_dir = os.path.join("..", "build", "bin")
     os.chdir(install_dir)
 
@@ -95,12 +95,12 @@ def test_runtime_execution():
     node_name = "Issue"
     assert check_node_exists(result_file, node_name)
 
-    os.chdir(start_wd)
+    # os.chdir(start_wd)
 
 
 def test_3steps_config():
 
-    start_wd = os.getcwd()
+    # start_wd = os.getcwd()
     install_dir = os.path.join("..", "build", "bin")
     os.chdir(install_dir)
 
@@ -135,4 +135,4 @@ def test_3steps_config():
     result_file = os.path.join("Report.txt")
     assert os.path.isfile(result_file)
 
-    os.chdir(start_wd)
+    # os.chdir(start_wd)

--- a/runtime/tests/test_runtime.py
+++ b/runtime/tests/test_runtime.py
@@ -57,7 +57,7 @@ def check_node_exists(xml_file: str, node_name: str) -> bool:
 
 def test_runtime_execution():
 
-    # start_wd = os.getcwd()
+    start_wd = os.getcwd()
     install_dir = os.path.join("..", "build", "bin")
     os.chdir(install_dir)
 
@@ -95,12 +95,12 @@ def test_runtime_execution():
     node_name = "Issue"
     assert check_node_exists(result_file, node_name)
 
-    # os.chdir(start_wd)
+    os.chdir(start_wd)
 
 
 def test_3steps_config():
 
-    # start_wd = os.getcwd()
+    start_wd = os.getcwd()
     install_dir = os.path.join("..", "build", "bin")
     os.chdir(install_dir)
 
@@ -135,4 +135,4 @@ def test_3steps_config():
     result_file = os.path.join("Report.txt")
     assert os.path.isfile(result_file)
 
-    # os.chdir(start_wd)
+    os.chdir(start_wd)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(qc4openx-common STATIC
 	src/xml/c_x_path_evaluator.cpp
     src/result_format/c_rule.cpp
     src/result_format/c_metadata.cpp
+    src/result_format/c_domain_specific_info.cpp
 )
 
 target_include_directories(qc4openx-common PUBLIC ${PROJECT_SOURCE_DIR}/include

--- a/src/common/src/config_format/c_configuration.cpp
+++ b/src/common/src/config_format/c_configuration.cpp
@@ -21,7 +21,6 @@ cConfiguration::~cConfiguration()
 
 bool cConfiguration::ParseFromXML(cConfiguration *config, const std::string &configFilePath)
 {
-    // XMLPlatformUtils::Initialize();
     if (!CheckIfFileExists(configFilePath))
         return false;
 
@@ -70,9 +69,6 @@ bool cConfiguration::ParseFromXML(cConfiguration *config, const std::string &con
     }
 
     delete pDomParser;
-
-    // XMLPlatformUtils::Terminate();
-
     return true;
 }
 
@@ -88,7 +84,6 @@ cConfiguration *cConfiguration::ParseFromXML(const std::string &configFilePath)
 
 void cConfiguration::WriteConfigurationToFile(const std::string &filePath)
 {
-    // XMLPlatformUtils::Initialize();
     DOMImplementation *p_DOMImplementationCore =
         DOMImplementationRegistry::getDOMImplementation(XMLString::transcode("core"));
     DOMLSSerializer *p_DOMSerializer = ((DOMImplementationLS *)p_DOMImplementationCore)->createLSSerializer();
@@ -130,8 +125,6 @@ void cConfiguration::WriteConfigurationToFile(const std::string &filePath)
     p_resultDocument->release();
     theOutput->release();
     p_DOMSerializer->release();
-
-    // XMLPlatformUtils::Terminate();
 }
 
 void cConfiguration::ProcessDomNode(DOMNode *const nodeToProcess, cConfiguration *const cConfig) const

--- a/src/common/src/config_format/c_configuration.cpp
+++ b/src/common/src/config_format/c_configuration.cpp
@@ -21,7 +21,7 @@ cConfiguration::~cConfiguration()
 
 bool cConfiguration::ParseFromXML(cConfiguration *config, const std::string &configFilePath)
 {
-    XMLPlatformUtils::Initialize();
+    // XMLPlatformUtils::Initialize();
     if (!CheckIfFileExists(configFilePath))
         return false;
 
@@ -71,7 +71,7 @@ bool cConfiguration::ParseFromXML(cConfiguration *config, const std::string &con
 
     delete pDomParser;
 
-    XMLPlatformUtils::Terminate();
+    // XMLPlatformUtils::Terminate();
 
     return true;
 }
@@ -88,7 +88,7 @@ cConfiguration *cConfiguration::ParseFromXML(const std::string &configFilePath)
 
 void cConfiguration::WriteConfigurationToFile(const std::string &filePath)
 {
-    XMLPlatformUtils::Initialize();
+    // XMLPlatformUtils::Initialize();
     DOMImplementation *p_DOMImplementationCore =
         DOMImplementationRegistry::getDOMImplementation(XMLString::transcode("core"));
     DOMLSSerializer *p_DOMSerializer = ((DOMImplementationLS *)p_DOMImplementationCore)->createLSSerializer();
@@ -131,7 +131,7 @@ void cConfiguration::WriteConfigurationToFile(const std::string &filePath)
     theOutput->release();
     p_DOMSerializer->release();
 
-    XMLPlatformUtils::Terminate();
+    // XMLPlatformUtils::Terminate();
 }
 
 void cConfiguration::ProcessDomNode(DOMNode *const nodeToProcess, cConfiguration *const cConfig) const

--- a/src/common/src/result_format/c_domain_specific_info.cpp
+++ b/src/common/src/result_format/c_domain_specific_info.cpp
@@ -16,10 +16,23 @@
 
 const XMLCh *cDomainSpecificInfo::TAG_DOMAIN_SPECIFIC_INFO = CONST_XMLCH("DomainSpecificInfo");
 const XMLCh *cDomainSpecificInfo::ATTR_NAME = CONST_XMLCH("name");
-// Returns the X
+// Returns the root
 DOMElement *cDomainSpecificInfo::GetRoot() const
 {
     return m_Root;
+}
+DOMDocument *cDomainSpecificInfo::GetDoc() const
+{
+    return m_Doc;
+}
+std::string cDomainSpecificInfo::GetName() const
+{
+    return m_Name;
+}
+
+cDomainSpecificInfo::~cDomainSpecificInfo()
+{
+    m_Doc->release();
 }
 
 DOMElement *cDomainSpecificInfo::WriteXML(DOMDocument *p_resultDocument)
@@ -42,6 +55,8 @@ DOMElement *cDomainSpecificInfo::WriteXML(DOMDocument *p_resultDocument)
 cDomainSpecificInfo *cDomainSpecificInfo::ParseFromXML(DOMNode *pXMLNode, DOMElement *pXMLElement)
 {
     std::string strName = XMLString::transcode(pXMLElement->getAttribute(ATTR_NAME));
-    cDomainSpecificInfo *domain_info = new cDomainSpecificInfo(pXMLElement, strName);
-    return domain_info;
+
+    cDomainSpecificInfo *domainInfo = new cDomainSpecificInfo(pXMLElement, strName);
+    // Return the parsed instance
+    return domainInfo;
 }

--- a/src/common/src/result_format/c_domain_specific_info.cpp
+++ b/src/common/src/result_format/c_domain_specific_info.cpp
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2024, ASAM e.V.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#include "common/result_format/c_domain_specific_info.h"
+#include <iostream>
+#include <string>
+#include <xercesc/dom/DOM.hpp>
+#include <xercesc/framework/MemBufInputSource.hpp>
+#include <xercesc/parsers/XercesDOMParser.hpp>
+#include <xercesc/sax/SAXParseException.hpp>
+#include <xercesc/util/PlatformUtils.hpp>
+
+const XMLCh *cDomainSpecificInfo::TAG_DOMAIN_SPECIFIC_INFO = CONST_XMLCH("DomainSpecificInfo");
+const XMLCh *cDomainSpecificInfo::ATTR_NAME = CONST_XMLCH("name");
+// Returns the X
+DOMElement *cDomainSpecificInfo::GetRoot() const
+{
+    return m_Root;
+}
+
+DOMElement *cDomainSpecificInfo::WriteXML(DOMDocument *p_resultDocument)
+{
+    DOMElement *p_DataElement = p_resultDocument->createElement(TAG_DOMAIN_SPECIFIC_INFO);
+    XMLCh *pName = XMLString::transcode(m_Name.c_str());
+    p_DataElement->setAttribute(ATTR_NAME, pName);
+
+    // Import the root element from the original document to the new document
+    DOMElement *importedRootElement = (DOMElement *)p_resultDocument->importNode(m_Root, true);
+    // Append the imported root element to the new document
+    p_DataElement->appendChild(importedRootElement);
+    // Return the appended root element
+
+    XMLString::release(&pName);
+
+    return importedRootElement;
+}
+
+cDomainSpecificInfo *cDomainSpecificInfo::ParseFromXML(DOMNode *pXMLNode, DOMElement *pXMLElement)
+{
+    std::string strName = XMLString::transcode(pXMLElement->getAttribute(ATTR_NAME));
+    cDomainSpecificInfo *domain_info = new cDomainSpecificInfo(pXMLElement, strName);
+    return domain_info;
+}

--- a/src/common/src/result_format/c_result_container.cpp
+++ b/src/common/src/result_format/c_result_container.cpp
@@ -58,7 +58,6 @@ void cResultContainer::Clear()
 
 void cResultContainer::WriteResults(const std::string &path) const
 {
-    XMLPlatformUtils::Initialize();
     DOMImplementation *p_DOMImplementationCore = DOMImplementationRegistry::getDOMImplementation(CONST_XMLCH("core"));
 
     // For storing a file, we need DOMImplementationLS
@@ -97,7 +96,6 @@ void cResultContainer::WriteResults(const std::string &path) const
     p_DOMSerializer->release();
 
     XMLString::release(&pPath);
-    XMLPlatformUtils::Terminate();
 }
 
 /*
@@ -118,7 +116,6 @@ void cResultContainer::AddResultsFromXML(const std::string &strXmlFilePath)
     }
     else
     {
-        XMLPlatformUtils::Initialize();
         xercesc::XercesDOMParser *pDomParser = new xercesc::XercesDOMParser();
 
         pDomParser->setValidationScheme(XercesDOMParser::Val_Never);
@@ -165,7 +162,6 @@ void cResultContainer::AddResultsFromXML(const std::string &strXmlFilePath)
         }
 
         delete pDomParser;
-        // XMLPlatformUtils::Terminate();
     }
 }
 

--- a/src/common/src/result_format/c_result_container.cpp
+++ b/src/common/src/result_format/c_result_container.cpp
@@ -165,7 +165,7 @@ void cResultContainer::AddResultsFromXML(const std::string &strXmlFilePath)
         }
 
         delete pDomParser;
-        XMLPlatformUtils::Terminate();
+        // XMLPlatformUtils::Terminate();
     }
 }
 

--- a/src/report_modules/report_module_gui/src/report_format_ui.cpp
+++ b/src/report_modules/report_module_gui/src/report_format_ui.cpp
@@ -31,6 +31,7 @@ int main(int argc, char *argv[])
     SetDllDirectory(currentPathW.c_str());
 #endif
 
+    XMLPlatformUtils::Initialize();
     std::string strToolpath = argv[0];
 
     if (argc > 2)
@@ -121,6 +122,7 @@ void ShowHelp(const std::string &toolPath)
 
 int RunReportGUI(const cParameterContainer &inputParams, const QApplication &app)
 {
+    XMLPlatformUtils::Initialize();
     cResultContainer *pResultContainer = new cResultContainer();
 
     std::string strXMLResultsPath = inputParams.GetParam("strInputFile");
@@ -150,6 +152,7 @@ int RunReportGUI(const cParameterContainer &inputParams, const QApplication &app
 
     pResultContainer->Clear();
     delete pResultContainer;
+    XMLPlatformUtils::Terminate();
 
     return execCode;
 }

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -130,6 +130,8 @@ void ShowHelp(const std::string &toolPath)
 
 void RunTextReport(const cParameterContainer &inputParams)
 {
+    XMLPlatformUtils::Initialize();
+
     cResultContainer *pResultContainer = new cResultContainer();
 
     try

--- a/src/result_pooling/src/result_pooling.cpp
+++ b/src/result_pooling/src/result_pooling.cpp
@@ -72,7 +72,6 @@ int main(int argc, char *argv[])
     }
 
     RunResultPooling(inputParams, resultsDirectory);
-
     return 0;
 }
 
@@ -93,6 +92,7 @@ void ShowHelp(const std::string &toolPath)
 
 void RunResultPooling(const cParameterContainer &inputParams, const fs::path &resultsDirectory)
 {
+    XMLPlatformUtils::Initialize();
     std::string strResultFile = inputParams.GetParam("strResultFile");
 
     pResultContainer = new cResultContainer();
@@ -140,6 +140,7 @@ void RunResultPooling(const cParameterContainer &inputParams, const fs::path &re
     std::cout << "Finished." << std::endl;
 
     delete pResultContainer;
+    XMLPlatformUtils::Terminate();
 }
 
 static void AddFileLocationsToIssues()

--- a/test/function/CMakeLists.txt
+++ b/test/function/CMakeLists.txt
@@ -7,6 +7,7 @@
 add_subdirectory(examples)
 add_subdirectory(report_modules)
 add_subdirectory(result_pooling/src)
+add_subdirectory(result_format/src)
 
 if (WIN32)
     # FIXME: We need some adaptions that this works in Linux
@@ -32,10 +33,15 @@ add_custom_command(
         COMMAND ${CMAKE_COMMAND} -E copy_directory
                 ${CMAKE_CURRENT_SOURCE_DIR}/runtime/files
                 ${REFERENCE_FILES_INSTALL_DIR}/function/runtime
-        
+
         COMMAND ${CMAKE_COMMAND} -E copy_directory
                 ${CMAKE_CURRENT_SOURCE_DIR}/../../doc/schema
                 ${REFERENCE_FILES_INSTALL_DIR}/doc/schema
+
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+                ${CMAKE_CURRENT_SOURCE_DIR}/result_format/files
+                ${REFERENCE_FILES_INSTALL_DIR}/function/result_format
+
     COMMENT "Copying test reference files..."
 )
 

--- a/test/function/result_format/files/result_domain_info.xqar
+++ b/test/function/result_format/files/result_domain_info.xqar
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 4 issues"
+    version="">
+    <Checker checkerId="exampleDomainChecker"
+      description="This is a description of example domain info checker" status="completed"
+      summary="">
+      <Issue description="This is an information from the demo usecase" issueId="3" level="3"
+        ruleUID="">
+        <DomainSpecificInfo name="test_domain">
+          <RoadLocation b="5.4" c="0.0" id="aa" />
+        </DomainSpecificInfo>
+      </Issue>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/test/function/result_format/src/CMakeLists.txt
+++ b/test/function/result_format/src/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright 2023 CARIAD SE.
+#
+# This Source Code Form is subject to the terms of the Mozilla
+# Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+set(TEST_NAME result_format_tester)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS true)
+
+find_package(XercesC REQUIRED)
+
+
+include_directories(${TEST_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../_common
+    ${XercesC_INCLUDE_DIRS})
+
+add_executable(${TEST_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../_common/helper.cpp
+    ${TEST_NAME}.cpp)
+
+add_test(NAME ${TEST_NAME}
+         COMMAND ${TEST_NAME}
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../
+)
+
+target_link_libraries(${TEST_NAME}
+    PRIVATE
+    GTest::gtest_main
+    $<$<PLATFORM_ID:Linux>:stdc++fs>
+    qc4openx-common
+
+    ${XercesC_LIBRARIES}
+)
+
+target_compile_definitions(${TEST_NAME}
+    PRIVATE QC4OPENX_DBQA_BIN_DIR="${QC4OPENX_DBQA_DIR}/examples/checker_bundle_example/bin"
+    PRIVATE QC4OPENX_DBQA_RESULT_FORMAT_TEST_WORK_DIR="${CMAKE_CURRENT_BINARY_DIR}/../../"
+    PRIVATE QC4OPENX_DBQA_RESULT_FORMAT_TEST_REF_DIR="${REFERENCE_FILES_INSTALL_DIR}/function/result_format")
+
+set_target_properties(${TEST_NAME} PROPERTIES FOLDER test/function)

--- a/test/function/result_format/src/CMakeLists.txt
+++ b/test/function/result_format/src/CMakeLists.txt
@@ -1,5 +1,4 @@
-# Copyright 2023 CARIAD SE.
-#
+# Copyright 2024, ASAM e.V.
 # This Source Code Form is subject to the terms of the Mozilla
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/test/function/result_format/src/result_format_tester.cpp
+++ b/test/function/result_format/src/result_format_tester.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "gtest/gtest.h"
+
+#include "common/result_format/c_checker_bundle.h"
+#include "common/result_format/c_domain_specific_info.h"
+#include "common/result_format/c_issue.h"
+#include "common/result_format/c_result_container.h"
+#include "helper.h"
+#include <xercesc/util/PlatformUtils.hpp>
+
+#define MODULE_NAME "ResultFormat"
+
+class cTesterResultFormat : public ::testing::Test
+{
+  public:
+    std::string strTestFilesDir = std::string(QC4OPENX_DBQA_RESULT_FORMAT_TEST_REF_DIR);
+    std::string strWorkingDir = std::string(QC4OPENX_DBQA_RESULT_FORMAT_TEST_WORK_DIR);
+};
+
+TEST_F(cTesterResultFormat, DomainSpecificInfoReadWrite)
+{
+    XERCES_CPP_NAMESPACE::XMLPlatformUtils::Initialize();
+    std::string strResultMessage;
+    std::string strFilePath = strTestFilesDir + "/result_domain_info.xqar";
+    std::string strResultFile = strWorkingDir + "/output.xqar";
+    std::string strXsdFilePath = strTestFilesDir + "/../../doc/schema/xqar_report_format.xsd";
+    // Check if xsd file exists
+    TestResult nRes = CheckFileExists(strResultMessage, strXsdFilePath, false);
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+
+    cResultContainer *pResultContainer = new cResultContainer();
+    // Parse results from xml
+    pResultContainer->AddResultsFromXML(strFilePath);
+
+    // Check domain specifc if is parsed
+    int domain_specific_info_count = 0;
+    std::list<cCheckerBundle *> checkerBundles = pResultContainer->GetCheckerBundles();
+    for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = checkerBundles.cbegin();
+         itCheckerBundle != checkerBundles.cend(); itCheckerBundle++)
+    {
+        std::list<cIssue *> issues = (*itCheckerBundle)->GetIssues();
+        for (std::list<cIssue *>::const_iterator itIssue = issues.cbegin(); itIssue != issues.cend(); itIssue++)
+        {
+            domain_specific_info_count += (*itIssue)->GetDomainSpecificCount();
+        }
+    }
+
+    std::cout << "Domain specific info count : " << domain_specific_info_count << std::endl;
+    ASSERT_TRUE_EXT(domain_specific_info_count > 0, "No domain specific info found");
+
+    // Write results to XML
+    pResultContainer->WriteResults(strResultFile);
+
+    // Check if output file exists
+    nRes |= CheckFileExists(strResultMessage, strResultFile, false);
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+    // Check if result file is valid according to xsd
+    nRes |= ValidateXmlSchema(strResultFile, strXsdFilePath);
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+
+    // Check if result file contains a specific tag
+    nRes |= XmlContainsNode(strFilePath, "RoadLocation");
+    ASSERT_TRUE_EXT(nRes == TestResult::ERR_NOERROR, strResultMessage.c_str());
+
+    delete pResultContainer;
+    XERCES_CPP_NAMESPACE::XMLPlatformUtils::Terminate();
+}

--- a/test/function/result_format/src/result_format_tester.cpp
+++ b/test/function/result_format/src/result_format_tester.cpp
@@ -1,5 +1,5 @@
-/*
- * Copyright 2023 CARIAD SE.
+/**
+ * Copyright 2024, ASAM e.V.
  *
  * This Source Code Form is subject to the terms of the Mozilla
  * Public License, v. 2.0. If a copy of the MPL was not distributed


### PR DESCRIPTION
**Description**

Addressing #10,  Add any xsd tag to schema to represent domain specific information

Add `cDomainSpecific` class to parse and write the xml in cpp codebase

`cDomainSpecific` is added as class attribute of `cIssue`

**How was the PR tested?**
1. Added generation of domain specific info to demo checker bundle

```
<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
<CheckerResults version="1.0.0">

  <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 4 issues" version="">
    <Checker checkerId="exampleDomainChecker" description="This is a description of example domain info checker" status="completed" summary="">
      <Issue description="This is an information from the demo usecase" issueId="3" level="3" ruleUID="">
        <DomainSpecificInfo name="test_domain">
          <RoadLocation b="5.4" c="0.0" id="aa"/>
        </DomainSpecificInfo>
      </Issue>
    </Checker>
  </CheckerBundle>

</CheckerResults>

```

**Notes**
