### PR TITLE
Fix branch name in workflow

### DIFF
--- a/.github/workflows/build-on-change-linux-bare.yaml
+++ b/.github/workflows/build-on-change-linux-bare.yaml
@@ -4,8 +4,8 @@ on:
   # execute on every PR made targeting the branches bellow
   pull_request:
     branches:
-      - master
-      - develop # can be removed on master merge
+      - main
+      - develop # can be removed on main merge
     paths: # we only include paths critical for building to avoid unnecessary runs
       - src/**
       - include/**
@@ -19,8 +19,8 @@ on:
   # execute on every push made targeting the branches bellow
   push:
     branches:
-      - master
-      - develop # can be removed on master merge
+      - main
+      - develop # can be removed on main merge
     paths: # we only include paths critical for building to avoid unnecessary runs
       - src/**
       - include/**

--- a/.github/workflows/build-on-change-linux-docker.yaml
+++ b/.github/workflows/build-on-change-linux-docker.yaml
@@ -4,8 +4,8 @@ on:
   # execute on every PR made targeting the branches bellow
   pull_request:
     branches:
-      - master
-      - develop # can be removed on master merge
+      - main
+      - develop # can be removed on main merge
     paths: # we only include paths critical for building to avoid unnecessary runs
       - src/**
       - include/**
@@ -19,8 +19,8 @@ on:
   # execute on every push made targeting the branches bellow
   push:
     branches:
-      - master
-      - develop # can be removed on master merge
+      - main
+      - develop # can be removed on main merge
     paths: # we only include paths critical for building to avoid unnecessary runs
       - src/**
       - include/**

--- a/.github/workflows/build-on-change-windows.yaml
+++ b/.github/workflows/build-on-change-windows.yaml
@@ -4,8 +4,8 @@ on:
   # execute on every PR made targeting the branches bellow
   pull_request:
     branches:
-      - master
-      - develop # can be removed on master merge
+      - main
+      - develop # can be removed on main merge
     paths: # we only include paths critical for building to avoid unnecessary runs
       - src/**
       - include/**
@@ -19,8 +19,8 @@ on:
   # execute on every push made targeting the branches bellow
   push:
     branches:
-      - master
-      - develop # can be removed on master merge
+      - main
+      - develop # can be removed on main merge
     paths: # we only include paths critical for building to avoid unnecessary runs
       - src/**
       - include/**


### PR DESCRIPTION
**Description**

Before, workflows are enabled in `master` and `develop`. It should be `main` and `develop`.

**Main changes**
1. Rename `master` to `main` in workflow files.

**How was the PR tested?**
1. Will be tested after this change is included in a PR targeting `main`.

**Notes**
