### PR TITLE
Add config option to result pooling

### DIFF
--- a/include/common/config_format/c_configuration_checker_bundle.h
+++ b/include/common/config_format/c_configuration_checker_bundle.h
@@ -80,6 +80,8 @@ class cConfigurationCheckerBundle
     // Overwrite parameters
     void OverwriteParams(const cParameterContainer &params);
 
+    std::vector<std::string> GetConfigurationCheckerIds();
+
   protected:
     std::string strApplication;
 

--- a/include/common/result_format/c_checker.h
+++ b/include/common/result_format/c_checker.h
@@ -184,6 +184,8 @@ class cChecker
      */
     cParameterContainer *GetParamContainer();
 
+    void FilterIssues(eIssueLevel minLevel, eIssueLevel maxLevel);
+
   protected:
     // Creates a new checker instance
     cChecker(const std::string &strCheckerId, const std::string &strDescription, const std::string &strSummary,

--- a/include/common/result_format/c_checker_bundle.h
+++ b/include/common/result_format/c_checker_bundle.h
@@ -235,6 +235,8 @@ class cCheckerBundle
      */
     cResultContainer const *GetResultContainer() const;
 
+    void KeepCheckersFrom(std::vector<std::string> checkerIds);
+
   protected:
     /*
      * Creates a new checker bundle

--- a/include/common/result_format/c_checker_bundle.h
+++ b/include/common/result_format/c_checker_bundle.h
@@ -77,6 +77,9 @@ class cCheckerBundle
     // Returns the checker id
     std::string GetCheckerID() const;
 
+    // Sets the name
+    void SetName(const std::string &strName);
+
     // Sets the summary
     void SetSummary(const std::string &strSummary);
 

--- a/include/common/result_format/c_checker_bundle.h
+++ b/include/common/result_format/c_checker_bundle.h
@@ -235,7 +235,7 @@ class cCheckerBundle
      */
     cResultContainer const *GetResultContainer() const;
 
-    void KeepCheckersFrom(std::vector<std::string> checkerIds);
+    void KeepCheckersFrom(const std::vector<std::string> &checkerIds);
 
   protected:
     /*

--- a/include/common/result_format/c_result_container.h
+++ b/include/common/result_format/c_result_container.h
@@ -129,7 +129,7 @@ class cResultContainer
      */
     void ConvertReportToConfiguration(cConfiguration *resultConfiguration);
 
-    cCheckerBundle *GetCheckerBundleByName(std::string &strBundleName) const;
+    cCheckerBundle *GetCheckerBundleByName(const std::string &strBundleName) const;
 
   protected:
     std::list<cCheckerBundle *> m_Bundles;

--- a/include/common/result_format/c_result_container.h
+++ b/include/common/result_format/c_result_container.h
@@ -129,6 +129,8 @@ class cResultContainer
      */
     void ConvertReportToConfiguration(cConfiguration *resultConfiguration);
 
+    cCheckerBundle *GetCheckerBundleByName(std::string &strBundleName) const;
+
   protected:
     std::list<cCheckerBundle *> m_Bundles;
 

--- a/src/common/src/config_format/c_configuration_checker_bundle.cpp
+++ b/src/common/src/config_format/c_configuration_checker_bundle.cpp
@@ -75,9 +75,9 @@ DOMElement *cConfigurationCheckerBundle::WriteXML(DOMDocument *pResultDocument, 
     // Add parameters
     m_params.WriteXML(pResultDocument, p_dataElement);
 
-    for (std::vector<cConfigurationChecker *>::const_iterator it = m_Checkers.begin(); it != m_Checkers.end(); ++it)
+    for (const auto &it : m_Checkers)
     {
-        (*it)->WriteXML(pResultDocument, p_dataElement);
+        it->WriteXML(pResultDocument, p_dataElement);
     }
 
     p_parentElement->appendChild(p_dataElement);
@@ -105,10 +105,10 @@ std::vector<cConfigurationChecker *> cConfigurationCheckerBundle::GetConfigurati
 
 void cConfigurationCheckerBundle::Clear()
 {
-    for (std::vector<cConfigurationChecker *>::iterator it = m_Checkers.begin(); it != m_Checkers.end(); it++)
+    for (const auto &it : m_Checkers)
     {
-        (*it)->Clear();
-        delete (*it);
+        it->Clear();
+        delete it;
     }
 
     m_Checkers.clear();
@@ -147,13 +147,12 @@ cConfigurationChecker *cConfigurationCheckerBundle::AddChecker(const std::string
 
 cConfigurationChecker *cConfigurationCheckerBundle::GetCheckerById(const std::string &checkerID) const
 {
-    std::vector<cConfigurationChecker *>::const_iterator it = m_Checkers.cbegin();
 
-    for (; it != m_Checkers.cend(); it++)
+    for (const auto &it : m_Checkers)
     {
-        if ((*it)->GetCheckerId() == checkerID)
+        if (it->GetCheckerId() == checkerID)
         {
-            return (*it);
+            return it;
         }
     }
 
@@ -162,11 +161,10 @@ cConfigurationChecker *cConfigurationCheckerBundle::GetCheckerById(const std::st
 
 bool cConfigurationCheckerBundle::HasCheckerWithId(const std::string &checkerID) const
 {
-    std::vector<cConfigurationChecker *>::const_iterator it = m_Checkers.cbegin();
 
-    for (; it != m_Checkers.cend(); it++)
+    for (const auto &it : m_Checkers)
     {
-        if ((*it)->GetCheckerId() == checkerID)
+        if (it->GetCheckerId() == checkerID)
         {
             return true;
         }
@@ -205,9 +203,9 @@ std::vector<std::string> cConfigurationCheckerBundle::GetConfigurationCheckerIds
     std::vector<std::string> result;
     std::vector<cConfigurationChecker *>::const_iterator it = m_Checkers.cbegin();
 
-    for (; it != m_Checkers.cend(); it++)
+    for (const auto &it : m_Checkers)
     {
-        result.push_back((*it)->GetCheckerId());
+        result.push_back(it->GetCheckerId());
     }
     return result;
 }

--- a/src/common/src/config_format/c_configuration_checker_bundle.cpp
+++ b/src/common/src/config_format/c_configuration_checker_bundle.cpp
@@ -199,3 +199,15 @@ void cConfigurationCheckerBundle::OverwriteParams(const cParameterContainer &par
 {
     m_params.Overwrite(params);
 }
+
+std::vector<std::string> cConfigurationCheckerBundle::GetConfigurationCheckerIds()
+{
+    std::vector<std::string> result;
+    std::vector<cConfigurationChecker *>::const_iterator it = m_Checkers.cbegin();
+
+    for (; it != m_Checkers.cend(); it++)
+    {
+        result.push_back((*it)->GetCheckerId());
+    }
+    return result;
+}

--- a/src/common/src/result_format/c_checker.cpp
+++ b/src/common/src/result_format/c_checker.cpp
@@ -438,15 +438,17 @@ unsigned long long cChecker::NextFreeId() const
 
 void cChecker::FilterIssues(eIssueLevel minLevel, eIssueLevel maxLevel)
 {
+    std::cout << "PRE SIZE " << m_Issues.size() << std::endl;
     for (std::list<cIssue *>::const_iterator itIssues = m_Issues.cbegin(); itIssues != m_Issues.cend(); itIssues++)
     {
         std::cout << "PRE: " << (*itIssues)->GetIssueId() << std::endl;
     }
 
     m_Issues.remove_if([minLevel, maxLevel](cIssue *item) {
-        return item->GetIssueLevel() < minLevel || item->GetIssueLevel() > maxLevel;
+        return item->GetIssueLevel() > minLevel || item->GetIssueLevel() < maxLevel;
     });
 
+    std::cout << "POST SIZE " << m_Issues.size() << std::endl;
     for (std::list<cIssue *>::const_iterator itIssues = m_Issues.cbegin(); itIssues != m_Issues.cend(); itIssues++)
     {
         std::cout << "POST: " << (*itIssues)->GetIssueId() << std::endl;

--- a/src/common/src/result_format/c_checker.cpp
+++ b/src/common/src/result_format/c_checker.cpp
@@ -438,19 +438,7 @@ unsigned long long cChecker::NextFreeId() const
 
 void cChecker::FilterIssues(eIssueLevel minLevel, eIssueLevel maxLevel)
 {
-    std::cout << "PRE SIZE " << m_Issues.size() << std::endl;
-    for (std::list<cIssue *>::const_iterator itIssues = m_Issues.cbegin(); itIssues != m_Issues.cend(); itIssues++)
-    {
-        std::cout << "PRE: " << (*itIssues)->GetIssueId() << std::endl;
-    }
-
     m_Issues.remove_if([minLevel, maxLevel](cIssue *item) {
         return item->GetIssueLevel() > minLevel || item->GetIssueLevel() < maxLevel;
     });
-
-    std::cout << "POST SIZE " << m_Issues.size() << std::endl;
-    for (std::list<cIssue *>::const_iterator itIssues = m_Issues.cbegin(); itIssues != m_Issues.cend(); itIssues++)
-    {
-        std::cout << "POST: " << (*itIssues)->GetIssueId() << std::endl;
-    }
 }

--- a/src/common/src/result_format/c_checker.cpp
+++ b/src/common/src/result_format/c_checker.cpp
@@ -435,3 +435,20 @@ unsigned long long cChecker::NextFreeId() const
         }
     }
 }
+
+void cChecker::FilterIssues(eIssueLevel minLevel, eIssueLevel maxLevel)
+{
+    for (std::list<cIssue *>::const_iterator itIssues = m_Issues.cbegin(); itIssues != m_Issues.cend(); itIssues++)
+    {
+        std::cout << "PRE: " << (*itIssues)->GetIssueId() << std::endl;
+    }
+
+    m_Issues.remove_if([minLevel, maxLevel](cIssue *item) {
+        return item->GetIssueLevel() < minLevel || item->GetIssueLevel() > maxLevel;
+    });
+
+    for (std::list<cIssue *>::const_iterator itIssues = m_Issues.cbegin(); itIssues != m_Issues.cend(); itIssues++)
+    {
+        std::cout << "POST: " << (*itIssues)->GetIssueId() << std::endl;
+    }
+}

--- a/src/common/src/result_format/c_checker_bundle.cpp
+++ b/src/common/src/result_format/c_checker_bundle.cpp
@@ -9,6 +9,7 @@
 
 #include "common/result_format/c_checker.h"
 #include "common/result_format/c_result_container.h"
+#include <unordered_set>
 
 XERCES_CPP_NAMESPACE_USE
 
@@ -494,4 +495,17 @@ cResultContainer const *cCheckerBundle::GetResultContainer() const
 void cCheckerBundle::AssignResultContainer(cResultContainer *container)
 {
     m_Container = container;
+}
+
+void cCheckerBundle::KeepCheckersFrom(std::vector<std::string> checkerIds)
+{
+    // Convert names to an unordered_set for efficient lookup
+    std::unordered_set<std::string> checkerSet(checkerIds.begin(), checkerIds.end());
+
+    // Use remove_if and erase to filter the items based on the names
+    m_Checkers.erase(std::remove_if(m_Checkers.begin(), m_Checkers.end(),
+                                    [&checkerSet](cChecker *item) {
+                                        return checkerSet.find(item->GetCheckerID()) == checkerSet.end();
+                                    }),
+                     m_Checkers.end());
 }

--- a/src/common/src/result_format/c_checker_bundle.cpp
+++ b/src/common/src/result_format/c_checker_bundle.cpp
@@ -184,6 +184,12 @@ void cCheckerBundle::Clear()
     m_Checkers.clear();
 }
 
+// Sets the name
+void cCheckerBundle::SetName(const std::string &strName)
+{
+    m_CheckerName = strName;
+}
+
 // Sets the summary
 void cCheckerBundle::SetSummary(const std::string &strSummary)
 {

--- a/src/common/src/result_format/c_checker_bundle.cpp
+++ b/src/common/src/result_format/c_checker_bundle.cpp
@@ -497,7 +497,7 @@ void cCheckerBundle::AssignResultContainer(cResultContainer *container)
     m_Container = container;
 }
 
-void cCheckerBundle::KeepCheckersFrom(std::vector<std::string> checkerIds)
+void cCheckerBundle::KeepCheckersFrom(const std::vector<std::string> &checkerIds)
 {
     // Convert names to an unordered_set for efficient lookup
     std::unordered_set<std::string> checkerSet(checkerIds.begin(), checkerIds.end());

--- a/src/common/src/result_format/c_result_container.cpp
+++ b/src/common/src/result_format/c_result_container.cpp
@@ -210,11 +210,11 @@ std::list<cChecker *> cResultContainer::GetCheckers(const std::string &parentChe
 {
     std::list<cChecker *> results;
 
-    for (std::list<cCheckerBundle *>::const_iterator it = m_Bundles.cbegin(); it != m_Bundles.cend(); it++)
+    for (const auto &it : m_Bundles)
     {
-        if (parentCheckerBundleName == (*it)->GetBundleName())
+        if (parentCheckerBundleName == it->GetBundleName())
         {
-            std::list<cChecker *> items = (*it)->GetCheckers();
+            std::list<cChecker *> items = it->GetCheckers();
             results.insert(results.end(), items.begin(), items.end());
         }
     }
@@ -229,19 +229,19 @@ std::list<cChecker *> cResultContainer::GetCheckers(cCheckerBundle *parentChecke
 
     if (parentCheckerBundle == nullptr)
     {
-        for (std::list<cCheckerBundle *>::const_iterator it = m_Bundles.cbegin(); it != m_Bundles.cend(); it++)
+        for (const auto &it : m_Bundles)
         {
-            std::list<cChecker *> items = (*it)->GetCheckers();
+            std::list<cChecker *> items = it->GetCheckers();
             results.insert(results.end(), items.begin(), items.end());
         }
     }
     else
     {
-        for (std::list<cCheckerBundle *>::const_iterator it = m_Bundles.cbegin(); it != m_Bundles.cend(); it++)
+        for (const auto &it : m_Bundles)
         {
-            if (parentCheckerBundle == (*it) || parentCheckerBundle->GetBundleName() == (*it)->GetBundleName())
+            if (parentCheckerBundle == it || parentCheckerBundle->GetBundleName() == it->GetBundleName())
             {
-                std::list<cChecker *> items = (*it)->GetCheckers();
+                std::list<cChecker *> items = it->GetCheckers();
                 results.insert(results.end(), items.begin(), items.end());
             }
         }
@@ -257,15 +257,13 @@ std::list<cIssue *> cResultContainer::GetIssues(cChecker *parentChecker) const
 
     if (parentChecker == nullptr)
     {
-        for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = m_Bundles.cbegin();
-             itCheckerBundle != m_Bundles.cend(); itCheckerBundle++)
+        for (const auto &itCheckerBundle : m_Bundles)
         {
-            std::list<cChecker *> checkers = (*itCheckerBundle)->GetCheckers();
+            std::list<cChecker *> checkers = itCheckerBundle->GetCheckers();
 
-            for (std::list<cChecker *>::const_iterator itCheckers = checkers.cbegin(); itCheckers != checkers.cend();
-                 itCheckers++)
+            for (const auto &itCheckers : checkers)
             {
-                std::list<cIssue *> issues = (*itCheckers)->GetIssues();
+                std::list<cIssue *> issues = itCheckers->GetIssues();
 
                 results.insert(results.end(), issues.begin(), issues.end());
             }
@@ -273,17 +271,15 @@ std::list<cIssue *> cResultContainer::GetIssues(cChecker *parentChecker) const
     }
     else
     {
-        for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = m_Bundles.cbegin();
-             itCheckerBundle != m_Bundles.cend(); itCheckerBundle++)
+        for (const auto &itCheckerBundle : m_Bundles)
         {
-            std::list<cChecker *> checkers = (*itCheckerBundle)->GetCheckers();
+            std::list<cChecker *> checkers = itCheckerBundle->GetCheckers();
 
-            for (std::list<cChecker *>::const_iterator itCheckers = checkers.cbegin(); itCheckers != checkers.cend();
-                 itCheckers++)
+            for (const auto &itCheckers : checkers)
             {
-                if (parentChecker == (*itCheckers) || parentChecker->GetCheckerID() == (*itCheckers)->GetCheckerID())
+                if (parentChecker == itCheckers || parentChecker->GetCheckerID() == itCheckers->GetCheckerID())
                 {
-                    std::list<cIssue *> issues = (*itCheckers)->GetIssues();
+                    std::list<cIssue *> issues = itCheckers->GetIssues();
 
                     results.insert(results.end(), issues.begin(), issues.end());
                 }
@@ -299,10 +295,9 @@ std::list<cIssue *> cResultContainer::GetIssues(std::list<cChecker *> checkersIn
 {
     std::list<cIssue *> results;
 
-    for (std::list<cChecker *>::const_iterator itCheckers = checkersInput.cbegin(); itCheckers != checkersInput.cend();
-         itCheckers++)
+    for (const auto &itCheckers : checkersInput)
     {
-        std::list<cIssue *> issues = (*itCheckers)->GetIssues();
+        std::list<cIssue *> issues = itCheckers->GetIssues();
 
         results.insert(results.end(), issues.begin(), issues.end());
     }
@@ -314,16 +309,15 @@ std::list<cIssue *> cResultContainer::GetIssuesByCheckerID(const std::string &ch
 {
     std::list<cIssue *> results;
 
-    for (std::list<cCheckerBundle *>::const_iterator it = m_Bundles.cbegin(); it != m_Bundles.cend(); it++)
+    for (const auto &it : m_Bundles)
     {
-        std::list<cChecker *> checkers = (*it)->GetCheckers();
+        std::list<cChecker *> checkers = it->GetCheckers();
 
-        for (std::list<cChecker *>::const_iterator itCheckers = checkers.cbegin(); itCheckers != checkers.cend();
-             itCheckers++)
+        for (const auto &itCheckers : checkers)
         {
-            if (Equals(checkerID, (*itCheckers)->GetCheckerID()))
+            if (Equals(checkerID, itCheckers->GetCheckerID()))
             {
-                std::list<cIssue *> issues = (*itCheckers)->GetIssues();
+                std::list<cIssue *> issues = itCheckers->GetIssues();
                 results.insert(results.end(), issues.begin(), issues.end());
             }
         }
@@ -334,10 +328,9 @@ std::list<cIssue *> cResultContainer::GetIssuesByCheckerID(const std::string &ch
 
 cIssue *cResultContainer::GetIssueById(unsigned long long id) const
 {
-    for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = m_Bundles.cbegin();
-         itCheckerBundle != m_Bundles.cend(); itCheckerBundle++)
+    for (const auto &itCheckerBundle : m_Bundles)
     {
-        cIssue *issue = (*itCheckerBundle)->GetIssueById(id);
+        cIssue *issue = itCheckerBundle->GetIssueById(id);
 
         if (nullptr != issue)
         {
@@ -363,10 +356,9 @@ bool cResultContainer::HasXOSCFilePath() const
 // Returns the xodr filename. Empty string if no file name is present.
 std::string cResultContainer::GetXODRFileName(const bool bRemoveExtension) const
 {
-    for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = m_Bundles.cbegin();
-         itCheckerBundle != m_Bundles.cend(); itCheckerBundle++)
+    for (const auto &itCheckerBundle : m_Bundles)
     {
-        std::string xodrFilename = (*itCheckerBundle)->GetXODRFileName(bRemoveExtension);
+        std::string xodrFilename = itCheckerBundle->GetXODRFileName(bRemoveExtension);
 
         if (!xodrFilename.empty())
             return xodrFilename;
@@ -378,10 +370,9 @@ std::string cResultContainer::GetXODRFileName(const bool bRemoveExtension) const
 // Returns the xodr path of the first checkerbundle. Empty string if no file name is present.
 std::string cResultContainer::GetXODRFilePath() const
 {
-    for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = m_Bundles.cbegin();
-         itCheckerBundle != m_Bundles.cend(); itCheckerBundle++)
+    for (const auto &itCheckerBundle : m_Bundles)
     {
-        std::string xodrFilepath = (*itCheckerBundle)->GetXODRFilePath();
+        std::string xodrFilepath = itCheckerBundle->GetXODRFilePath();
 
         if (!xodrFilepath.empty())
             return xodrFilepath;
@@ -393,10 +384,9 @@ std::string cResultContainer::GetXODRFilePath() const
 // Returns the xodr path of the first checkerbundle. Empty std::string if no file name is present.
 std::string cResultContainer::GetXOSCFilePath() const
 {
-    for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = m_Bundles.cbegin();
-         itCheckerBundle != m_Bundles.cend(); itCheckerBundle++)
+    for (const auto &itCheckerBundle : m_Bundles)
     {
-        std::string xoscFilepath = (*itCheckerBundle)->GetXOSCFilePath();
+        std::string xoscFilepath = itCheckerBundle->GetXOSCFilePath();
 
         if (!xoscFilepath.empty())
             return xoscFilepath;
@@ -408,19 +398,17 @@ std::string cResultContainer::GetXOSCFilePath() const
 // Processes every issue on every checkerbundle, checker and does a defined processing
 void cResultContainer::DoProcessing(void (*funcIteratorPtr)(cCheckerBundle *, cChecker *, cIssue *))
 {
-    for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = m_Bundles.begin();
-         itCheckerBundle != m_Bundles.end(); itCheckerBundle++)
+    for (const auto &itCheckerBundle : m_Bundles)
     {
-        std::list<cChecker *> checkers = (*itCheckerBundle)->GetCheckers();
+        std::list<cChecker *> checkers = itCheckerBundle->GetCheckers();
 
-        for (std::list<cChecker *>::const_iterator itChecker = checkers.begin(); itChecker != checkers.end();
-             itChecker++)
+        for (const auto &itChecker : checkers)
         {
-            std::list<cIssue *> issues = (*itChecker)->GetIssues();
+            std::list<cIssue *> issues = itChecker->GetIssues();
 
-            for (std::list<cIssue *>::const_iterator itIssue = issues.begin(); itIssue != issues.end(); itIssue++)
+            for (const auto &itIssue : issues)
             {
-                funcIteratorPtr(*itCheckerBundle, *itChecker, *itIssue);
+                funcIteratorPtr(itCheckerBundle, itChecker, itIssue);
             }
         }
     }
@@ -481,14 +469,13 @@ void cResultContainer::ConvertReportToConfiguration(cConfiguration *resultConfig
     }
 }
 
-cCheckerBundle *cResultContainer::GetCheckerBundleByName(std::string &strBundleName) const
+cCheckerBundle *cResultContainer::GetCheckerBundleByName(const std::string &strBundleName) const
 {
-    for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = m_Bundles.cbegin();
-         itCheckerBundle != m_Bundles.cend(); itCheckerBundle++)
+    for (const auto &itCheckerBundle : m_Bundles)
     {
-        if ((*itCheckerBundle)->GetBundleName() == strBundleName)
+        if (itCheckerBundle->GetBundleName() == strBundleName)
         {
-            return (*itCheckerBundle);
+            return itCheckerBundle;
         }
     }
 

--- a/src/common/src/result_format/c_result_container.cpp
+++ b/src/common/src/result_format/c_result_container.cpp
@@ -480,3 +480,17 @@ void cResultContainer::ConvertReportToConfiguration(cConfiguration *resultConfig
         }
     }
 }
+
+cCheckerBundle *cResultContainer::GetCheckerBundleByName(std::string &strBundleName) const
+{
+    for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = m_Bundles.cbegin();
+         itCheckerBundle != m_Bundles.cend(); itCheckerBundle++)
+    {
+        if ((*itCheckerBundle)->GetBundleName() == strBundleName)
+        {
+            return (*itCheckerBundle);
+        }
+    }
+
+    return nullptr;
+}

--- a/src/result_pooling/src/result_pooling.cpp
+++ b/src/result_pooling/src/result_pooling.cpp
@@ -44,7 +44,6 @@ bool isDirectory(const std::string &path)
 int main(int argc, char *argv[])
 {
     XMLPlatformUtils::Initialize();
-    QCoreApplication app(argc, argv);
 
     std::vector<std::string> args(argv, argv + argc);
     std::string strToolpath = args[0];
@@ -269,44 +268,44 @@ void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path
 
     fs::path result_path = resultsDirectory;
 
-    // int max_level = INT_MAX;
-    // int min_level = INT_MIN;
+    int max_level = INT_MAX;
+    int min_level = INT_MIN;
 
-    // // Get minLevel (highest value) and maxLevel (lowest value) across all bundles
-    // std::vector<cConfigurationCheckerBundle *> checkerBundleConfigs = configuration.GetCheckerBundles();
-    // for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs.cbegin();
-    //      itCheckerBundles != checkerBundleConfigs.end(); itCheckerBundles++)
-    // {
-    //     std::vector<cConfigurationChecker *> checkers = (*itCheckerBundles)->GetCheckers();
+    // Get minLevel (highest value) and maxLevel (lowest value) across all bundles
+    std::vector<cConfigurationCheckerBundle *> checkerBundleConfigs = configuration.GetCheckerBundles();
+    for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs.cbegin();
+         itCheckerBundles != checkerBundleConfigs.end(); itCheckerBundles++)
+    {
+        std::vector<cConfigurationChecker *> checkers = (*itCheckerBundles)->GetCheckers();
 
-    //     for (std::vector<cConfigurationChecker *>::const_iterator itChecker = checkers.cbegin();
-    //          itChecker != checkers.end(); itChecker++)
-    //     {
-    //         int current_min_level = (*itChecker)->GetMinLevel();
-    //         int current_max_level = (*itChecker)->GetMaxLevel();
-    //         if (current_min_level > min_level)
-    //         {
-    //             min_level = current_min_level;
-    //         }
-    //         if (current_max_level < max_level)
-    //         {
-    //             max_level = current_max_level;
-    //         }
-    //     }
-    // }
+        for (std::vector<cConfigurationChecker *>::const_iterator itChecker = checkers.cbegin();
+             itChecker != checkers.end(); itChecker++)
+        {
+            int current_min_level = (*itChecker)->GetMinLevel();
+            int current_max_level = (*itChecker)->GetMaxLevel();
+            if (current_min_level > min_level)
+            {
+                min_level = current_min_level;
+            }
+            if (current_max_level < max_level)
+            {
+                max_level = current_max_level;
+            }
+        }
+    }
 
-    // for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs.cbegin();
-    //      itCheckerBundles != checkerBundleConfigs.end(); itCheckerBundles++)
-    // {
-    //     std::vector<cConfigurationChecker *> checkers = (*itCheckerBundles)->GetCheckers();
+    for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs.cbegin();
+         itCheckerBundles != checkerBundleConfigs.end(); itCheckerBundles++)
+    {
+        std::vector<cConfigurationChecker *> checkers = (*itCheckerBundles)->GetCheckers();
 
-    //     for (std::vector<cConfigurationChecker *>::const_iterator itChecker = checkers.cbegin();
-    //          itChecker != checkers.end(); itChecker++)
-    //     {
-    //         (*itChecker)->SetMinLevel(static_cast<eIssueLevel>(min_level));
-    //         (*itChecker)->SetMaxLevel(static_cast<eIssueLevel>(max_level));
-    //     }
-    // }
+        for (std::vector<cConfigurationChecker *>::const_iterator itChecker = checkers.cbegin();
+             itChecker != checkers.end(); itChecker++)
+        {
+            (*itChecker)->SetMinLevel(static_cast<eIssueLevel>(min_level));
+            (*itChecker)->SetMaxLevel(static_cast<eIssueLevel>(max_level));
+        }
+    }
 
     std::vector<cConfigurationCheckerBundle *> checkerBundleConfigs3 = configuration.GetCheckerBundles();
     for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs3.cbegin();
@@ -328,7 +327,7 @@ void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path
         }
 
         // Add checker bundle result to pooled reuslts
-        pResultContainer->AddResultsFromXML(full_path);
+        pResultContainer->AddResultsFromXML(full_path.string());
     }
 
     // Handle CheckerBundle naming - if collision then append 0-indexed occurrence number (abc, abc1, abc2,...)

--- a/src/result_pooling/src/result_pooling.cpp
+++ b/src/result_pooling/src/result_pooling.cpp
@@ -44,6 +44,8 @@ bool isDirectory(const std::string &path)
 int main(int argc, char *argv[])
 {
     XMLPlatformUtils::Initialize();
+    QCoreApplication app(argc, argv);
+
     std::vector<std::string> args(argv, argv + argc);
     std::string strToolpath = args[0];
 
@@ -169,6 +171,8 @@ void ShowHelp(const std::string &toolPath)
     GetFileName(&applicationNameWithoutExt, true);
 
     std::cout << "\n\nUsage of " << applicationNameWithoutExt << ":" << std::endl;
+    std::cout << "\nRun the application to summarize all xqar files from current directory: \n"
+              << applicationName << std::endl;
     std::cout << "\nRun the application to summarize all xqar files from current directory with given config: \n"
               << applicationName << " config.xml " << std::endl;
     std::cout << "\nRun the application to summarize all xqar files from a specified directory with given config: \n"
@@ -265,44 +269,44 @@ void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path
 
     fs::path result_path = resultsDirectory;
 
-    int max_level = INT_MAX;
-    int min_level = INT_MIN;
+    // int max_level = INT_MAX;
+    // int min_level = INT_MIN;
 
-    // Get minLevel (highest value) and maxLevel (lowest value) across all bundles
-    std::vector<cConfigurationCheckerBundle *> checkerBundleConfigs = configuration.GetCheckerBundles();
-    for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs.cbegin();
-         itCheckerBundles != checkerBundleConfigs.end(); itCheckerBundles++)
-    {
-        std::vector<cConfigurationChecker *> checkers = (*itCheckerBundles)->GetCheckers();
+    // // Get minLevel (highest value) and maxLevel (lowest value) across all bundles
+    // std::vector<cConfigurationCheckerBundle *> checkerBundleConfigs = configuration.GetCheckerBundles();
+    // for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs.cbegin();
+    //      itCheckerBundles != checkerBundleConfigs.end(); itCheckerBundles++)
+    // {
+    //     std::vector<cConfigurationChecker *> checkers = (*itCheckerBundles)->GetCheckers();
 
-        for (std::vector<cConfigurationChecker *>::const_iterator itChecker = checkers.cbegin();
-             itChecker != checkers.end(); itChecker++)
-        {
-            int current_min_level = (*itChecker)->GetMinLevel();
-            int current_max_level = (*itChecker)->GetMaxLevel();
-            if (current_min_level > min_level)
-            {
-                min_level = current_min_level;
-            }
-            if (current_max_level < max_level)
-            {
-                max_level = current_max_level;
-            }
-        }
-    }
+    //     for (std::vector<cConfigurationChecker *>::const_iterator itChecker = checkers.cbegin();
+    //          itChecker != checkers.end(); itChecker++)
+    //     {
+    //         int current_min_level = (*itChecker)->GetMinLevel();
+    //         int current_max_level = (*itChecker)->GetMaxLevel();
+    //         if (current_min_level > min_level)
+    //         {
+    //             min_level = current_min_level;
+    //         }
+    //         if (current_max_level < max_level)
+    //         {
+    //             max_level = current_max_level;
+    //         }
+    //     }
+    // }
 
-    for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs.cbegin();
-         itCheckerBundles != checkerBundleConfigs.end(); itCheckerBundles++)
-    {
-        std::vector<cConfigurationChecker *> checkers = (*itCheckerBundles)->GetCheckers();
+    // for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs.cbegin();
+    //      itCheckerBundles != checkerBundleConfigs.end(); itCheckerBundles++)
+    // {
+    //     std::vector<cConfigurationChecker *> checkers = (*itCheckerBundles)->GetCheckers();
 
-        for (std::vector<cConfigurationChecker *>::const_iterator itChecker = checkers.cbegin();
-             itChecker != checkers.end(); itChecker++)
-        {
-            (*itChecker)->SetMinLevel(static_cast<eIssueLevel>(min_level));
-            (*itChecker)->SetMaxLevel(static_cast<eIssueLevel>(max_level));
-        }
-    }
+    //     for (std::vector<cConfigurationChecker *>::const_iterator itChecker = checkers.cbegin();
+    //          itChecker != checkers.end(); itChecker++)
+    //     {
+    //         (*itChecker)->SetMinLevel(static_cast<eIssueLevel>(min_level));
+    //         (*itChecker)->SetMaxLevel(static_cast<eIssueLevel>(max_level));
+    //     }
+    // }
 
     std::vector<cConfigurationCheckerBundle *> checkerBundleConfigs3 = configuration.GetCheckerBundles();
     for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs3.cbegin();

--- a/src/result_pooling/src/result_pooling.cpp
+++ b/src/result_pooling/src/result_pooling.cpp
@@ -261,10 +261,9 @@ void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path
     fs::path result_path = resultsDirectory;
 
     std::vector<cConfigurationCheckerBundle *> checkerBundleConfigs = configuration.GetCheckerBundles();
-    for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs.cbegin();
-         itCheckerBundles != checkerBundleConfigs.end(); itCheckerBundles++)
+    for (const auto &itCheckerBundles : checkerBundleConfigs)
     {
-        std::string current_result_file = (*itCheckerBundles)->GetParam("strResultFile");
+        std::string current_result_file = itCheckerBundles->GetParam("strResultFile");
 
         // Convert std::string to std::filesystem::path
         fs::path current_result_path = current_result_file;
@@ -283,19 +282,16 @@ void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path
     }
 
     // Get minLevel (highest value) and maxLevel (lowest value) of each checker
-    for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundleConfig =
-             checkerBundleConfigs.cbegin();
-         itCheckerBundleConfig != checkerBundleConfigs.end(); itCheckerBundleConfig++)
+    for (const auto &itCheckerBundleConfig : checkerBundleConfigs)
     {
-        std::vector<cConfigurationChecker *> checkersConfigs = (*itCheckerBundleConfig)->GetCheckers();
-        std::string config_checker_bundle_name = (*itCheckerBundleConfig)->GetCheckerBundleApplication();
+        std::vector<cConfigurationChecker *> checkersConfigs = itCheckerBundleConfig->GetCheckers();
+        std::string config_checker_bundle_name = itCheckerBundleConfig->GetCheckerBundleApplication();
 
-        for (std::vector<cConfigurationChecker *>::const_iterator itCheckerConfig = checkersConfigs.cbegin();
-             itCheckerConfig != checkersConfigs.end(); itCheckerConfig++)
+        for (const auto &itCheckerConfig : checkersConfigs)
         {
-            eIssueLevel config_min_level = (*itCheckerConfig)->GetMinLevel();
-            eIssueLevel config_max_level = (*itCheckerConfig)->GetMaxLevel();
-            std::string config_checker_id = (*itCheckerConfig)->GetCheckerId();
+            eIssueLevel config_min_level = itCheckerConfig->GetMinLevel();
+            eIssueLevel config_max_level = itCheckerConfig->GetMaxLevel();
+            std::string config_checker_id = itCheckerConfig->GetCheckerId();
 
             cCheckerBundle *itCheckerBundle = pResultContainer->GetCheckerBundleByName(config_checker_bundle_name);
 
@@ -309,7 +305,7 @@ void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path
             // Filter Checker Bundle results from configuration, so that the result after the pooling only
             // contains issues from configured checks, even if the Checker Bundle reports more issues from other
             // checks
-            std::vector<std::string> checkerIds = (*itCheckerBundleConfig)->GetConfigurationCheckerIds();
+            std::vector<std::string> checkerIds = itCheckerBundleConfig->GetConfigurationCheckerIds();
             itCheckerBundle->KeepCheckersFrom(checkerIds);
 
             // evaluate minimal/maximal issue level and adjust level in result
@@ -337,15 +333,14 @@ void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path
     // Handle CheckerBundle naming - if collision then append 0-indexed occurrence number (abc, abc1, abc2,...)
     std::unordered_map<std::string, int> bundle_names_count;
     std::list<cCheckerBundle *> checkerBundles = pResultContainer->GetCheckerBundles();
-    for (std::list<cCheckerBundle *>::const_iterator itCheckerBundles = checkerBundles.cbegin();
-         itCheckerBundles != checkerBundles.end(); itCheckerBundles++)
+    for (const auto &itCheckerBundles : checkerBundles)
     {
-        std::string current_bundle_name = (*itCheckerBundles)->GetBundleName();
+        std::string current_bundle_name = itCheckerBundles->GetBundleName();
         if (bundle_names_count.find(current_bundle_name) == bundle_names_count.end())
         {
             // If the string is not in the map, add it
             bundle_names_count[current_bundle_name] = 0;
-            (*itCheckerBundles)->SetName(current_bundle_name);
+            itCheckerBundles->SetName(current_bundle_name);
         }
         else
         {
@@ -354,7 +349,7 @@ void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path
             std::ostringstream oss;
             oss << current_bundle_name << count; // Append the count to the string
             std::string new_str = oss.str();
-            (*itCheckerBundles)->SetName(new_str);
+            itCheckerBundles->SetName(new_str);
         }
     }
 
@@ -374,14 +369,13 @@ static void AddFileLocationsToIssues()
 {
     // Calculate and set file location for ervery xml location
     std::list<cCheckerBundle *> checkerBundles = pResultContainer->GetCheckerBundles();
-    for (std::list<cCheckerBundle *>::const_iterator itCheckerBundle = checkerBundles.cbegin();
-         itCheckerBundle != checkerBundles.cend(); itCheckerBundle++)
+    for (const auto &itCheckerBundle : checkerBundles)
     {
         cXPathEvaluator xodrXPathEvaluator;
         cXPathEvaluator xoscXPathEvaluator;
 
-        std::string xodrFilePath = (*itCheckerBundle)->GetXODRFilePath();
-        std::string xoscFilePath = (*itCheckerBundle)->GetXOSCFilePath();
+        std::string xodrFilePath = itCheckerBundle->GetXODRFilePath();
+        std::string xoscFilePath = itCheckerBundle->GetXOSCFilePath();
 
         // Init xml files on xpath evaluators
         bool successXodrContent = false;
@@ -393,10 +387,10 @@ static void AddFileLocationsToIssues()
             successXoscContent = xoscXPathEvaluator.SetXmlContent(QString::fromStdString(xoscFilePath));
 
         // Evaluate XPath for every issue and set calculated file location
-        std::list<cIssue *> issues = (*itCheckerBundle)->GetIssues();
-        for (std::list<cIssue *>::const_iterator itIssue = issues.cbegin(); itIssue != issues.cend(); itIssue++)
+        std::list<cIssue *> issues = itCheckerBundle->GetIssues();
+        for (const auto &itIssue : issues)
         {
-            for (const auto location : (*itIssue)->GetLocationsContainer())
+            for (const auto location : itIssue->GetLocationsContainer())
             {
                 // Check for xml Location
                 std::list<cExtendedInformation *> extInformations = location->GetExtendedInformations();

--- a/src/result_pooling/src/result_pooling.cpp
+++ b/src/result_pooling/src/result_pooling.cpp
@@ -394,10 +394,9 @@ static void AddFileLocationsToIssues()
             {
                 // Check for xml Location
                 std::list<cExtendedInformation *> extInformations = location->GetExtendedInformations();
-                for (std::list<cExtendedInformation *>::const_iterator extIt = extInformations.cbegin();
-                     extIt != extInformations.cend(); extIt++)
+                for (const auto &extIt : extInformations)
                 {
-                    cXMLLocation *xmlLocation = dynamic_cast<cXMLLocation *>(*extIt);
+                    cXMLLocation *xmlLocation = dynamic_cast<cXMLLocation *>(extIt);
                     if (nullptr != xmlLocation)
                     {
                         // Calculate and set file location

--- a/src/result_pooling/src/result_pooling.cpp
+++ b/src/result_pooling/src/result_pooling.cpp
@@ -7,6 +7,8 @@
  */
 #include "result_pooling.h"
 #include "common/config_format/c_configuration.h"
+#include "common/config_format/c_configuration_checker.h"
+#include "common/config_format/c_configuration_checker_bundle.h"
 #include "common/result_format/c_checker_bundle.h"
 #include "common/result_format/c_file_location.h"
 #include "common/result_format/c_inertial_location.h"
@@ -20,18 +22,99 @@
 
 cResultContainer *pResultContainer;
 
+bool isXmlFile(const std::string &filename)
+{
+    const std::string extension = ".xml";
+    if (filename.size() >= extension.size() &&
+        filename.compare(filename.size() - extension.size(), extension.size(), extension) == 0)
+    {
+        return true;
+    }
+    return false;
+}
+
+bool isDirectory(const std::string &path)
+{
+    return fs::is_directory(path);
+}
+
 // Main Programm
 int main(int argc, char *argv[])
 {
-    std::string strToolpath = argv[0];
+    XMLPlatformUtils::Initialize();
+    std::vector<std::string> args(argv, argv + argc);
+    std::string strToolpath = args[0];
 
-    if (argc > 2)
+    bool config_file_set = false;
+    bool result_dir_set = false;
+    std::string config_file;
+    std::string result_dir;
+
+    if (args.size() == 1)
     {
-        ShowHelp(strToolpath);
-        return -1;
+        // No arguments provided other than the program name
+        std::cout << "No arguments provided.\n";
     }
+    else if (args.size() == 2)
+    {
+        // One argument provided
+        std::string arg = args[1];
+        if (arg == "-h" || arg == "--help")
+        {
+            ShowHelp(strToolpath);
+            return 0;
+        }
+        else if (isXmlFile(arg))
+        {
+            config_file = arg;
+            config_file_set = true;
+        }
+        else if (isDirectory(arg))
+        {
+            result_dir = arg;
+            result_dir_set = true;
+        }
+        else
+        {
+            std::cerr << "Invalid argument: " << arg << "\n";
+            return 1; // Return error code
+        }
+    }
+    else if (args.size() == 3)
+    {
+        // Two arguments provided
+        std::string arg1 = args[1];
+        std::string arg2 = args[2];
 
-    QCoreApplication app(argc, argv);
+        if (isXmlFile(arg1) && isDirectory(arg2))
+        {
+            std::cout << "Configuration file: " << arg1 << "\n";
+            std::cout << "Results directory: " << arg2 << "\n";
+            config_file = arg1;
+            result_dir = arg2;
+            config_file_set = true;
+            result_dir_set = true;
+        }
+        else if (isDirectory(arg1) && isXmlFile(arg2))
+        {
+            std::cout << "Results directory: " << arg1 << "\n";
+            std::cout << "Configuration file: " << arg2 << "\n";
+            result_dir = arg1;
+            config_file = arg2;
+            config_file_set = true;
+            result_dir_set = true;
+        }
+        else
+        {
+            std::cerr << "Invalid arguments: " << arg1 << " and " << arg2 << "\n";
+            return 1; // Return error code
+        }
+    }
+    else
+    {
+        std::cerr << "Invalid number of arguments.\n";
+        return 1; // Return error code
+    }
 
     cParameterContainer inputParams;
 
@@ -39,39 +122,40 @@ int main(int argc, char *argv[])
     inputParams.SetParam("strResultFile", "Result.xqar");
     fs::path resultsDirectory = GetWorkingDir();
 
-    if (argc == 2) // else: use default parameter
+    // If specified, use second argument to specify result directory, else: use default parameter
+    if (result_dir_set)
     {
-        std::string strFilepath = argv[1];
-
-        if (strcmp(strFilepath.c_str(), "-h") == 0 || strcmp(strFilepath.c_str(), "--help") == 0)
-        {
-            ShowHelp(strToolpath);
-            return 0;
-        }
+        // Compute path to result files
+        fs::path pFilepath = result_dir;
+        if (pFilepath.is_absolute())
+            resultsDirectory = pFilepath;
         else
         {
-            // Compute path to result files
-            fs::path pFilepath = strFilepath;
-            if (pFilepath.is_absolute())
-                resultsDirectory = pFilepath;
+            if ("/" == result_dir)
+                resultsDirectory += result_dir;
             else
-            {
-                if ("/" == strFilepath)
-                    resultsDirectory += strFilepath;
-                else
-                    resultsDirectory = resultsDirectory.append(strFilepath);
-            }
-
-            if (!exists(resultsDirectory))
-            {
-                std::cerr << "Directory '" << resultsDirectory << "' does not exist!" << std::endl
-                          << "Abort generating report!" << std::endl;
-                return -1;
-            }
+                resultsDirectory = resultsDirectory.append(result_dir);
+        }
+        std::cout << "resultsDirectory: " << resultsDirectory << std::endl;
+        if (!exists(resultsDirectory))
+        {
+            std::cerr << "Directory '" << resultsDirectory << "' does not exist!" << std::endl
+                      << "Abort generating report!" << std::endl;
+            return -1;
         }
     }
 
-    RunResultPooling(inputParams, resultsDirectory);
+    if (config_file_set)
+    {
+        RunResultPoolingWithConfig(inputParams, resultsDirectory, config_file);
+    }
+    else
+    {
+        RunResultPooling(inputParams, resultsDirectory);
+    }
+
+    XMLPlatformUtils::Terminate();
+
     return 0;
 }
 
@@ -83,16 +167,15 @@ void ShowHelp(const std::string &toolPath)
     GetFileName(&applicationNameWithoutExt, true);
 
     std::cout << "\n\nUsage of " << applicationNameWithoutExt << ":" << std::endl;
-    std::cout << "\nRun the application to summarize all xqar files from current directory: \n"
-              << applicationName << std::endl;
-    std::cout << "\nRun the application to summarize all xqar files from a specified directory: \n"
-              << applicationName << " ../results/" << std::endl;
+    std::cout << "\nRun the application to summarize all xqar files from current directory with given config: \n"
+              << applicationName << " config.xml " << std::endl;
+    std::cout << "\nRun the application to summarize all xqar files from a specified directory with given config: \n"
+              << applicationName << " config.xml ../results/" << std::endl;
     std::cout << "\n\n";
 }
 
 void RunResultPooling(const cParameterContainer &inputParams, const fs::path &resultsDirectory)
 {
-    XMLPlatformUtils::Initialize();
     std::string strResultFile = inputParams.GetParam("strResultFile");
 
     pResultContainer = new cResultContainer();
@@ -140,7 +223,85 @@ void RunResultPooling(const cParameterContainer &inputParams, const fs::path &re
     std::cout << "Finished." << std::endl;
 
     delete pResultContainer;
-    XMLPlatformUtils::Terminate();
+}
+
+void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path &resultsDirectory,
+                                const std::string &configFile)
+{
+    cConfiguration configuration;
+
+    std::cout << "Config: " << configFile << std::endl;
+    if (!cConfiguration::ParseFromXML(&configuration, configFile))
+    {
+        std::cerr << "Could not read configuration! Abort." << std::endl;
+        return;
+    }
+    inputParams.Overwrite(configuration.GetParams());
+
+    std::string strResultFile = inputParams.GetParam("strResultFile");
+
+    pResultContainer = new cResultContainer();
+
+    std::cout << std::endl;
+
+    // Delete old result file in working directory
+    std::cout << "Cleanup: ";
+    if (fs::exists(strResultFile))
+    {
+        std::cout << "Delete: " << std::endl;
+        std::cout << ">  " << strResultFile;
+
+        QFile file(strResultFile.c_str());
+        file.remove();
+    }
+    std::cout << std::endl << std::endl;
+    std::cout << "Collect results from directory: " << std::endl
+              << resultsDirectory << std::endl
+              << "According to config file: " << std::endl
+              << configFile << std::endl;
+
+    std::vector<cConfigurationCheckerBundle *> checkerBundleConfigs = configuration.GetCheckerBundles();
+    for (std::vector<cConfigurationCheckerBundle *>::const_iterator itCheckerBundles = checkerBundleConfigs.cbegin();
+         itCheckerBundles != checkerBundleConfigs.end(); itCheckerBundles++)
+    {
+        std::cout << "----> result file " << (*itCheckerBundles)->GetParam("strResultFile") << std::endl;
+        std::vector<cConfigurationChecker *> checkers = (*itCheckerBundles)->GetCheckers();
+
+        for (std::vector<cConfigurationChecker *>::const_iterator itChecker = checkers.cbegin();
+             itChecker != checkers.end(); itChecker++)
+        {
+            std::cout << "----> checker id " << (*itChecker)->GetCheckerId() << std::endl;
+        }
+    }
+
+    std::cout << "Found: " << std::endl;
+    for (auto &pFilePath : fs::directory_iterator(resultsDirectory))
+    {
+        std::string strFilePath = pFilePath.path().string();
+        std::string strFileName = strFilePath;
+        GetFileName(&strFileName, false);
+
+        // Check if we have an result file in the resultsDirectory
+        if (ToLower(strFileName) == ToLower(strResultFile))
+            continue;
+
+        if (StringEndsWith(strFileName, "xqar"))
+        {
+            std::cout << ">  " << strFileName << "\t\tReading..." << std::endl;
+            pResultContainer->AddResultsFromXML(strFilePath);
+        }
+    }
+
+    std::cout << std::endl << "Find locations in xml file..." << std::endl << std::endl;
+
+    AddFileLocationsToIssues();
+
+    std::cout << "Write report: '" << strResultFile << "'" << std::endl << std::endl;
+    pResultContainer->WriteResults(strResultFile);
+
+    std::cout << "Finished." << std::endl;
+
+    delete pResultContainer;
 }
 
 static void AddFileLocationsToIssues()

--- a/src/result_pooling/src/result_pooling.cpp
+++ b/src/result_pooling/src/result_pooling.cpp
@@ -272,7 +272,6 @@ void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path
          itCheckerBundles != checkerBundleConfigs3.end(); itCheckerBundles++)
     {
         std::string current_result_file = (*itCheckerBundles)->GetParam("strResultFile");
-        std::cout << "----> result file " << current_result_file << std::endl;
 
         // Convert std::string to std::filesystem::path
         fs::path current_result_path = current_result_file;
@@ -310,20 +309,25 @@ void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path
             for (std::list<cCheckerBundle *>::const_iterator itCheckerBundles = checkerBundles.cbegin();
                  itCheckerBundles != checkerBundles.end(); itCheckerBundles++)
             {
-                std::cout << "(*itCheckerBundles)->GetBundleName() " << (*itCheckerBundles)->GetBundleName()
-                          << std::endl;
-                std::cout << "config_checker_bundle_name " << config_checker_bundle_name << std::endl;
                 if ((*itCheckerBundles)->GetBundleName() == config_checker_bundle_name)
                 {
                     std::list<cChecker *> checkers = (*itCheckerBundles)->GetCheckers();
                     for (std::list<cChecker *>::const_iterator itChecker = checkers.cbegin();
                          itChecker != checkers.end(); itChecker++)
                     {
-                        std::cout << "(*itChecker)->GetCheckerID() " << (*itChecker)->GetCheckerID() << std::endl;
-                        std::cout << "config_checker_id " << config_checker_id << std::endl;
                         if ((*itChecker)->GetCheckerID() == config_checker_id)
                         {
+                            unsigned int pre_size = (*itChecker)->GetIssueCount();
                             (*itChecker)->FilterIssues(config_min_level, config_max_level);
+                            unsigned int post_size = (*itChecker)->GetIssueCount();
+                            if ((pre_size - post_size) > 0)
+                            {
+                                std::cout << "Filtering checker " << config_checker_id << " results. " << std::endl
+                                          << "Keeping issues between level " << config_min_level << " and "
+                                          << config_max_level << std::endl;
+                                std::cout << "Filtered " << (pre_size - post_size) << " issues " << std::endl
+                                          << std::endl;
+                            }
                             break;
                         }
                     }

--- a/src/result_pooling/src/result_pooling.h
+++ b/src/result_pooling/src/result_pooling.h
@@ -36,6 +36,12 @@ void ShowHelp(const std::string &applicationName);
  */
 void RunResultPooling(const cParameterContainer &inputParams, const fs::path &pathToResults);
 
+/**
+ * Runs the result pooling with given config file
+ */
+void RunResultPoolingWithConfig(cParameterContainer &inputParams, const fs::path &pathToResults,
+                                const std::string &configFile);
+
 /*!
  * Loop over the issues of the checker bundles of the result container:
  * Convert the xml location of the issues in a file location

--- a/test/function/result_pooling/files/DemoCheckerBundle.xqar
+++ b/test/function/result_pooling/files/DemoCheckerBundle.xqar
@@ -1,16 +1,32 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-<!--
-Copyright 2023 CARIAD SE.
-
-This Source Code Form is subject to the terms of the Mozilla
-Public License, v. 2.0. If a copy of the MPL was not distributed
-with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
--->
 <CheckerResults version="1.0.0">
 
-  <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 1 issue" version="">
-    <Checker checkerId="exampleChecker" description="This is a description" summary="">
-      <Issue description="This is an information from the demo usecase" issueId="0" level="3"/>
+  <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 4 issues" version="">
+    <Checker checkerId="exampleChecker" description="This is a description" status="completed" summary="">
+      <Issue description="This is an information from the demo usecase" issueId="0" level="3" ruleUID=""/>
+    </Checker>
+    <Checker checkerId="exampleInertialChecker" description="This is a description of inertial checker" status="completed" summary="">
+      <Issue description="This is an information from the demo usecase" issueId="1" level="3" ruleUID="">
+        <Locations description="inertial position">
+          <InertialLocation x="1.000000" y="2.000000" z="3.000000"/>
+        </Locations>
+      </Issue>
+    </Checker>
+    <Checker checkerId="exampleRuleUIDChecker" description="This is a description of ruleUID checker" status="completed" summary="">
+      <AddressedRule ruleUID="test.com::qwerty.qwerty"/>
+      <Metadata description="Date in which the checker was executed" key="run date" value="2024/06/06"/>
+      <Metadata description="Name of the project that created the checker" key="reference project" value="project01"/>
+    </Checker>
+    <Checker checkerId="exampleIssueRuleChecker" description="This is a description of checker with issue and the involved ruleUID" status="completed" summary="">
+      <Issue description="This is an information from the demo usecase" issueId="2" level="1" ruleUID="test.com::qwerty.qwerty"/>
+    </Checker>
+    <Checker checkerId="exampleSkippedChecker" description="This is a description of checker with skipped status" status="skipped" summary="Skipped execution"/>
+    <Checker checkerId="exampleDomainChecker" description="This is a description of example domain info checker" status="completed" summary="">
+      <Issue description="This is an information from the demo usecase" issueId="3" level="3" ruleUID="">
+        <DomainSpecificInfo name="test_domain">
+          <RoadLocation b="5.4" c="0.0" id="aa"/>
+        </DomainSpecificInfo>
+      </Issue>
     </Checker>
   </CheckerBundle>
 

--- a/test/function/result_pooling/files/DemoCheckerBundle2.xqar
+++ b/test/function/result_pooling/files/DemoCheckerBundle2.xqar
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="" description="" name="DemoCheckerBundle2" summary="Found 4 issues"
+    version="">
+    <Checker checkerId="exampleChecker" description="This is a description" status="completed"
+      summary="">
+      <Issue description="This is an information from the demo usecase" issueId="0" level="3"
+        ruleUID="" />
+    </Checker>
+    <Checker checkerId="exampleInertialChecker"
+      description="This is a description of inertial checker" status="completed" summary="">
+      <Issue description="This is an information from the demo usecase" issueId="1" level="3"
+        ruleUID="">
+        <Locations description="inertial position">
+          <InertialLocation x="1.000000" y="2.000000" z="3.000000" />
+        </Locations>
+      </Issue>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/test/function/result_pooling/files/two_bundles_config.xml
+++ b/test/function/result_pooling/files/two_bundles_config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Config>
+
+  <Param name="XodrFile" value="../stimuli/xodr_examples/three_connected_roads_with_steps.xodr" />
+
+  <CheckerBundle application="DemoCheckerBundle">
+    <Param name="strResultFile" value="DemoCheckerBundle.xqar" />
+    <Checker checkerId="exampleIssueRuleChecker" maxLevel="2" minLevel="2" />
+    <Checker checkerId="exampleDomainChecker" maxLevel="2" minLevel="2" />
+  </CheckerBundle>
+
+  <CheckerBundle application="DemoCheckerBundle2">
+    <Param name="strResultFile" value="DemoCheckerBundle2.xqar" />
+    <Checker checkerId="exampleChecker" maxLevel="1" minLevel="3" />
+    <Checker checkerId="exampleInertialChecker" maxLevel="1" minLevel="3" />
+  </CheckerBundle>
+
+
+  <ReportModule application="TextReport">
+    <Param name="strInputFile" value="Result.xqar" />
+    <Param name="strReportFile" value="Report.txt" />
+  </ReportModule>
+
+</Config>

--- a/test/function/result_pooling/files/two_bundles_result.xqar
+++ b/test/function/result_pooling/files/two_bundles_result.xqar
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<CheckerResults version="1.0.0">
+
+  <CheckerBundle build_date="" description="" name="DemoCheckerBundle" summary="Found 4 issues"
+    version="">
+    <Checker checkerId="exampleIssueRuleChecker"
+      description="This is a description of checker with issue and the involved ruleUID"
+      status="completed" summary="" />
+    <Checker checkerId="exampleDomainChecker"
+      description="This is a description of example domain info checker" status="completed"
+      summary="" />
+  </CheckerBundle>
+
+  <CheckerBundle build_date="" description="" name="DemoCheckerBundle2" summary="Found 4 issues"
+    version="">
+    <Checker checkerId="exampleChecker" description="This is a description" status="completed"
+      summary="">
+      <Issue description="This is an information from the demo usecase" issueId="4" level="3"
+        ruleUID="" />
+    </Checker>
+    <Checker checkerId="exampleInertialChecker"
+      description="This is a description of inertial checker" status="completed" summary="">
+      <Issue description="This is an information from the demo usecase" issueId="5" level="3"
+        ruleUID="">
+        <Locations description="inertial position">
+          <InertialLocation x="1.000000" y="2.000000" z="3.000000" />
+        </Locations>
+      </Issue>
+    </Checker>
+  </CheckerBundle>
+
+</CheckerResults>

--- a/test/function/result_pooling/src/CMakeLists.txt
+++ b/test/function/result_pooling/src/CMakeLists.txt
@@ -11,11 +11,11 @@ set_property(GLOBAL PROPERTY USE_FOLDERS true)
 
 find_package(XercesC REQUIRED)
 
-include_directories(${TEST_NAME} PRIVATE 
+include_directories(${TEST_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../_common
     ${XercesC_INCLUDE_DIRS})
 
-add_executable(${TEST_NAME}         
+add_executable(${TEST_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../_common/helper.cpp
     ${TEST_NAME}.cpp)
 
@@ -28,13 +28,13 @@ target_link_libraries(${TEST_NAME}
     PRIVATE
     GTest::gtest_main
     $<$<PLATFORM_ID:Linux>:stdc++fs>
+    qc4openx-common
     ${XercesC_LIBRARIES}
 )
 
-target_compile_definitions(${TEST_NAME} 
+target_compile_definitions(${TEST_NAME}
     PRIVATE QC4OPENX_DBQA_BIN_DIR="${QC4OPENX_DBQA_DIR}/bin"
     PRIVATE QC4OPENX_DBQA_RESULT_POOLING_TEST_WORK_DIR="${CMAKE_CURRENT_BINARY_DIR}/../../"
     PRIVATE QC4OPENX_DBQA_RESULT_POOLING_TEST_REF_DIR="${REFERENCE_FILES_INSTALL_DIR}/function/result_pooling")
 
 set_target_properties(${TEST_NAME} PROPERTIES FOLDER test/function)
-


### PR DESCRIPTION
**Description**

Addressing https://github.com/asam-ev/qc-framework/issues/33 
Improve result pooling by
- Adding the option to read configuration file and select which checker to read with which order
- Handle colliding names by appending 0-based CheckerBundle occurence in case of repeated CheckerBundle names
- Filter checker results issues using `minLevel` and `maxLevel` specified in each checker config

Now the ResultPooling interface is:

```
Usage of ResultPooling:

Run the application to summarize all xqar files from current directory: 
ResultPooling

Run the application to summarize all xqar files from a specified directory: 
ResultPooling ../results/ 

Run the application to summarize all xqar files from current directory with given config: 
ResultPooling config.xml 

Run the application to summarize all xqar files from a specified directory with given config: 
ResultPooling ../results/ config.xml 



```

**How was the PR tested?**
1. Unit-test with some sample data. All unit tests passed.


**Notes**
