### PR TITLE
Add report module GitHub ci

### DIFF
--- a/src/report_modules/CMakeLists.txt
+++ b/src/report_modules/CMakeLists.txt
@@ -7,3 +7,4 @@
 
 add_subdirectory(report_module_text)
 add_subdirectory(report_module_gui)
+add_subdirectory(report_module_github_ci)

--- a/src/report_modules/report_module_github_ci/CMakeLists.txt
+++ b/src/report_modules/report_module_github_ci/CMakeLists.txt
@@ -5,19 +5,18 @@
 # Public License, v. 2.0. If a copy of the MPL was not distributed
 # with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-set(REPORT_MODULE_TEXT_PROJECT "GithubCIReport")
-project(${REPORT_MODULE_TEXT_PROJECT})
+set(REPORT_MODULE_GITHUB_CI_PROJECT "GithubCIReport")
+project(${REPORT_MODULE_GITHUB_CI_PROJECT})
 
-add_executable(${REPORT_MODULE_TEXT_PROJECT}
+add_executable(${REPORT_MODULE_GITHUB_CI_PROJECT}
     src/stdafx.h
     src/stdafx.cpp
     src/report_format_github_ci.h
     src/report_format_github_ci.cpp
 )
 
-target_link_libraries(${REPORT_MODULE_TEXT_PROJECT} PRIVATE qc4openx-common $<$<PLATFORM_ID:Linux>:stdc++fs>)
+target_link_libraries(${REPORT_MODULE_GITHUB_CI_PROJECT} PRIVATE qc4openx-common $<$<PLATFORM_ID:Linux>:stdc++fs>)
 
-install(TARGETS ${REPORT_MODULE_TEXT_PROJECT} DESTINATION bin)
-qc4openx_install_qt(bin ${REPORT_MODULE_TEXT_PROJECT}${CMAKE_EXECUTABLE_SUFFIX})
+install(TARGETS ${REPORT_MODULE_GITHUB_CI_PROJECT} DESTINATION bin)
 
-set_target_properties(${REPORT_MODULE_TEXT_PROJECT} PROPERTIES FOLDER report_modules)
+set_target_properties(${REPORT_MODULE_GITHUB_CI_PROJECT} PROPERTIES FOLDER report_modules)

--- a/src/report_modules/report_module_github_ci/CMakeLists.txt
+++ b/src/report_modules/report_module_github_ci/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright 2023 CARIAD SE.
+# Copyright 2024 BMW AG
+#
+# This Source Code Form is subject to the terms of the Mozilla
+# Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set(REPORT_MODULE_TEXT_PROJECT "GithubCIReport")
+project(${REPORT_MODULE_TEXT_PROJECT})
+
+add_executable(${REPORT_MODULE_TEXT_PROJECT}
+    src/stdafx.h
+    src/stdafx.cpp
+    src/report_format_github_ci.h
+    src/report_format_github_ci.cpp
+)
+
+target_link_libraries(${REPORT_MODULE_TEXT_PROJECT} PRIVATE qc4openx-common $<$<PLATFORM_ID:Linux>:stdc++fs>)
+
+install(TARGETS ${REPORT_MODULE_TEXT_PROJECT} DESTINATION bin)
+qc4openx_install_qt(bin ${REPORT_MODULE_TEXT_PROJECT}${CMAKE_EXECUTABLE_SUFFIX})
+
+set_target_properties(${REPORT_MODULE_TEXT_PROJECT} PROPERTIES FOLDER report_modules)

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -28,7 +28,7 @@ XERCES_CPP_NAMESPACE_USE
 const char BASIC_SEPARATOR_LINE[] =
     "====================================================================================================\n";
 
-static std::map<eIssueLevel, std::string> mapIssueLevelToString = {{eIssueLevel::INFO_LVL, "::info::"},
+static std::map<eIssueLevel, std::string> mapIssueLevelToString = {{eIssueLevel::INFO_LVL, "::notice::"},
                                                                    {eIssueLevel::WARNING_LVL, "::warning::"},
                                                                    {eIssueLevel::ERROR_LVL, "::error::"}};
 

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -25,9 +25,6 @@
 
 XERCES_CPP_NAMESPACE_USE
 
-const char BASIC_SEPARATOR_LINE[] =
-    "====================================================================================================\n";
-
 static std::map<eIssueLevel, std::string> mapIssueLevelToString = {{eIssueLevel::INFO_LVL, "::notice::"},
                                                                    {eIssueLevel::WARNING_LVL, "::warning::"},
                                                                    {eIssueLevel::ERROR_LVL, "::error::"}};

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -139,7 +139,7 @@ bool RunGithubCIReport(const cParameterContainer &inputParams)
         pResultContainer->AddResultsFromXML(inputParams.GetParam("strInputFile"));
 
         // Add prefix with issue id
-        std::list<cCheckerBundle *> checkerBundles = pResultContainer->GetCheckerBundles();
+        const std::list<cCheckerBundle *> checkerBundles = pResultContainer->GetCheckerBundles();
         for (auto checkerBundle:  checkerBundles)
         {
             checkerBundle->DoProcessing(AddPrefixForDescriptionIssueProcessor);

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -165,19 +165,16 @@ bool PrintResults(cResultContainer *ptrResultContainer)
     bool error_found = false;
 
     std::list<cCheckerBundle *> bundles = ptrResultContainer->GetCheckerBundles();
-    std::list<cChecker *> checkers;
-    std::list<cIssue *> issues;
-
     // Loop over all checker bundles
     for (auto & bundle : bundles)
     {
-        checkers = bundle->GetCheckers();
+        const auto checkers = bundle->GetCheckers();
 
         // Iterate over all checkers
         for (auto & checker : checkers)
         {
             // Get all issues from the current checker
-            issues = checker->GetIssues();
+            const auto issues = checker->GetIssues();
             if (!issues.empty())
             {
                 for (auto & issue : issues)

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -128,7 +128,7 @@ bool RunGithubCIReport(const cParameterContainer &inputParams)
 {
     XMLPlatformUtils::Initialize();
 
-    auto *pResultContainer(new cResultContainer());
+    std::unique_ptr<cResultContainer> pResultContainer(new cResultContainer());
 
     bool error_found;
 
@@ -157,14 +157,14 @@ bool RunGithubCIReport(const cParameterContainer &inputParams)
 }
 
 // Prints results in GitHub CI format
-bool PrintResults(cResultContainer *ptrResultContainer)
+bool PrintResults(std::unique_ptr<cResultContainer> &pResultContainer)
 {
-    if (!ptrResultContainer->HasCheckerBundles())
+    if (!pResultContainer->HasCheckerBundles())
         return false;
 
     bool error_found = false;
 
-    std::list<cCheckerBundle *> bundles = ptrResultContainer->GetCheckerBundles();
+    std::list<cCheckerBundle *> bundles = pResultContainer->GetCheckerBundles();
     // Loop over all checker bundles
     for (auto & bundle : bundles)
     {

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -140,9 +140,9 @@ bool RunGithubCIReport(const cParameterContainer &inputParams)
 
         // Add prefix with issue id
         std::list<cCheckerBundle *> checkerBundles = pResultContainer->GetCheckerBundles();
-        for (auto checkerBundles:  checkerBundles)
+        for (auto checkerBundle:  checkerBundles)
         {
-            (*itCheckerBundles)->DoProcessing(AddPrefixForDescriptionIssueProcessor);
+            checkerBundle->DoProcessing(AddPrefixForDescriptionIssueProcessor);
         }
 
         error_found = PrintResults(pResultContainer);

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -128,7 +128,7 @@ bool RunGithubCIReport(const cParameterContainer &inputParams)
 {
     XMLPlatformUtils::Initialize();
 
-    std::unique_ptr<cResultContainer> pResultContainer(new cResultContainer());
+    auto pResultContainer = std::make_unique<cResultContainer>();
 
     bool error_found;
 

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -128,7 +128,7 @@ bool RunGithubCIReport(const cParameterContainer &inputParams)
 {
     XMLPlatformUtils::Initialize();
 
-    auto *pResultContainer = new cResultContainer();
+    auto *pResultContainer(new cResultContainer());
 
     bool error_found;
 
@@ -151,9 +151,6 @@ bool RunGithubCIReport(const cParameterContainer &inputParams)
     catch (...)
     {
     }
-
-    pResultContainer->Clear();
-    delete pResultContainer;
 
     XMLPlatformUtils::Terminate();
 

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
 
     if (StringEndsWith(ToLower(strFilepath), ".xqar"))
     {
-        if (stat(strFilepath.c_str(), &fileStatus) == -1) // ==0 ok; ==-1 error
+        if (!std::filesystem::exists(strFilepath.c_str()))
         {
             std::cerr << "Could not open file '" << strFilepath << "'!" << std::endl
                       << "Abort generating report!" << std::endl;

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -32,7 +32,7 @@ static std::map<eIssueLevel, std::string> mapIssueLevelToString = {{eIssueLevel:
 // Main Programm
 int main(int argc, char *argv[])
 {
-    std::string strToolpath = argv[0];
+    const std::string strToolpath(argv[0]);
 
     if (argc != 2)
     {

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -140,8 +140,7 @@ bool RunGithubCIReport(const cParameterContainer &inputParams)
 
         // Add prefix with issue id
         std::list<cCheckerBundle *> checkerBundles = pResultContainer->GetCheckerBundles();
-        for (auto itCheckerBundles = checkerBundles.cbegin();
-             itCheckerBundles != checkerBundles.end(); itCheckerBundles++)
+        for (auto checkerBundles:  checkerBundles)
         {
             (*itCheckerBundles)->DoProcessing(AddPrefixForDescriptionIssueProcessor);
         }

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2023 CARIAD SE.
+ * Copyright 2024 BMW AG
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#include "report_format_github_ci.h"
+#include "common/config_format/c_configuration.h"
+#include "common/config_format/c_configuration_report_module.h"
+#include "common/result_format/c_checker.h"
+#include "common/result_format/c_checker_bundle.h"
+#include "common/result_format/c_domain_specific_info.h"
+#include "common/result_format/c_issue.h"
+#include "common/result_format/c_locations_container.h"
+#include "common/result_format/c_metadata.h"
+#include "common/result_format/c_parameter_container.h"
+#include "common/result_format/c_result_container.h"
+#include "common/result_format/c_xml_location.h"
+#include "stdafx.h"
+
+#include "common/qc4openx_filesystem.h"
+#include <set>
+
+XERCES_CPP_NAMESPACE_USE
+
+const char BASIC_SEPARATOR_LINE[] =
+    "====================================================================================================\n";
+
+static std::map<eIssueLevel, std::string> mapIssueLevelToString = {{eIssueLevel::INFO_LVL, "::info::"},
+                                                                   {eIssueLevel::WARNING_LVL, "::warning::"},
+                                                                   {eIssueLevel::ERROR_LVL, "::error::"}};
+
+// Main Programm
+int main(int argc, char *argv[])
+{
+    std::string strToolpath = argv[0];
+
+    if (argc != 2)
+    {
+        ShowHelp(strToolpath);
+
+        if (argc < 2)
+            return 0;
+        else
+            return -1;
+    }
+
+    std::string strFilepath = argv[1];
+    struct stat fileStatus;
+
+    XMLPlatformUtils::Initialize();
+
+    cParameterContainer inputParams;
+
+    // Default parameters
+    inputParams.SetParam("strInputFile", "Result.xqar");
+
+    if (StringEndsWith(ToLower(strFilepath), ".xqar"))
+    {
+        if (stat(strFilepath.c_str(), &fileStatus) == -1) // ==0 ok; ==-1 error
+        {
+            std::cerr << "Could not open file '" << strFilepath << "'!" << std::endl
+                      << "Abort generating report!" << std::endl;
+            return 1;
+        }
+
+        inputParams.SetParam("strInputFile", strFilepath);
+    }
+    else if (StringEndsWith(ToLower(strFilepath), ".xml"))
+    {
+        cConfiguration configuration;
+
+        std::cout << "Config: " << strFilepath << std::endl;
+        if (!cConfiguration::ParseFromXML(&configuration, strFilepath))
+        {
+            std::cerr << "Could not read configuration! Abort." << std::endl;
+            return -1;
+        }
+
+        inputParams.Overwrite(configuration.GetParams());
+
+        cConfigurationReportModule *reportModuleConfig = configuration.GetReportModuleByName(REPORT_MODULE_NAME);
+        if (nullptr != reportModuleConfig)
+            inputParams.Overwrite(reportModuleConfig->GetParams());
+        else
+            std::cerr << "No configuration for module '" << REPORT_MODULE_NAME << "' found. Start with default params."
+                      << std::endl;
+    }
+    else if (StringEndsWith(ToLower(strFilepath), "--defaultconfig"))
+    {
+        WriteDefaultConfig();
+        return 0;
+    }
+    else if (strcmp(strFilepath.c_str(), "-h") == 0 || strcmp(strFilepath.c_str(), "--help") == 0)
+    {
+        ShowHelp(strToolpath);
+        return 0;
+    }
+    else
+    {
+        ShowHelp(strToolpath);
+        XMLPlatformUtils::Terminate();
+        return -1;
+    }
+
+    RunGithubCIReport(inputParams);
+}
+
+void ShowHelp(const std::string &toolPath)
+{
+    std::string applicationName = toolPath;
+    std::string applicationNameWithoutExt = toolPath;
+    GetFileName(&applicationName, false);
+    GetFileName(&applicationNameWithoutExt, true);
+
+    std::cout << "\n\nUsage of " << applicationNameWithoutExt << ":" << std::endl;
+    std::cout << "\nRun the application with xqar file: \n" << applicationName << " result.xqar" << std::endl;
+    std::cout << "\nRun the application with dbqa configuration: \n" << applicationName << " config.xml" << std::endl;
+    std::cout << "\nRun the application with and write default configuration: \n"
+              << applicationName << " --defaultconfig" << std::endl;
+    std::cout << "\n\n";
+}
+
+
+void RunGithubCIReport(const cParameterContainer &inputParams)
+{
+    XMLPlatformUtils::Initialize();
+
+    auto *pResultContainer = new cResultContainer();
+
+    try
+    {
+        std::cout << "Read result file: '" << inputParams.GetParam("strInputFile") << "' ..." << std::endl << std::endl;
+
+        pResultContainer->AddResultsFromXML(inputParams.GetParam("strInputFile"));
+
+        // Add prefix with issue id
+        std::list<cCheckerBundle *> checkerBundles = pResultContainer->GetCheckerBundles();
+        for (auto itCheckerBundles = checkerBundles.cbegin();
+             itCheckerBundles != checkerBundles.end(); itCheckerBundles++)
+        {
+            (*itCheckerBundles)->DoProcessing(AddPrefixForDescriptionIssueProcessor);
+        }
+
+        PrintResults(pResultContainer);
+    }
+    catch (...)
+    {
+    }
+
+    pResultContainer->Clear();
+    delete pResultContainer;
+
+    XMLPlatformUtils::Terminate();
+}
+
+// Prints results in GitHub CI format
+void PrintResults(cResultContainer *ptrResultContainer)
+{
+    if (!ptrResultContainer->HasCheckerBundles())
+        return;
+
+    std::list<cCheckerBundle *> bundles = ptrResultContainer->GetCheckerBundles();
+    std::list<cChecker *> checkers;
+    std::list<cIssue *> issues;
+
+    // Loop over all checker bundles
+    for (auto & bundle : bundles)
+    {
+        checkers = bundle->GetCheckers();
+
+        // Iterate over all checkers
+        for (auto & checker : checkers)
+        {
+            // Get all issues from the current checker
+            issues = checker->GetIssues();
+            if (!issues.empty())
+            {
+                for (auto & issue : issues)
+                {
+                    std::cout << mapIssueLevelToString[issue->GetIssueLevel()]
+                              << checker->GetCheckerID()
+                              << ": "
+                              << issue->GetDescription()
+                              << std::endl;
+                }
+            }
+        }
+    }
+}
+
+
+void AddPrefixForDescriptionIssueProcessor(cChecker *, cIssue *issueToProcess)
+{
+    std::stringstream ssDescription;
+    ssDescription << "#" << issueToProcess->GetIssueId() << ": " << issueToProcess->GetDescription();
+
+    issueToProcess->SetDescription(ssDescription.str());
+}
+
+
+void WriteDefaultConfig()
+{
+    cConfiguration defaultConfig;
+
+    cConfigurationReportModule *reportModuleConfig = defaultConfig.AddReportModule(REPORT_MODULE_NAME);
+    reportModuleConfig->SetParam("strInputFile", "Result.xqar");
+
+    std::stringstream ssConfigFile;
+    ssConfigFile << REPORT_MODULE_NAME << ".xml";
+
+    std::cout << std::endl;
+    std::cout << "Write default config: '" << ssConfigFile.str() << "'" << std::endl << std::endl;
+    defaultConfig.WriteConfigurationToFile(ssConfigFile.str());
+
+    std::cout << "Finished." << std::endl;
+}

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -179,14 +179,18 @@ bool PrintResults(std::unique_ptr<cResultContainer> &pResultContainer)
             {
                 for (auto & issue : issues)
                 {
-                    std::cout << mapIssueLevelToString[issue->GetIssueLevel()]
-                              << checker->GetCheckerID()
-                              << ": "
-                              << issue->GetDescription()
-                              << std::endl;
-                    if (issue->GetIssueLevel() == eIssueLevel::ERROR_LVL)
+                    auto issue_level = mapIssueLevelToString.find(issue->GetIssueLevel());
+                    if (issue_level != mapIssueLevelToString.end())
                     {
-                        error_found = true;
+                        std::cout << issue_level->second
+                                  << checker->GetCheckerID()
+                                  << ": "
+                                  << issue->GetDescription()
+                                  << std::endl;
+                        if (issue->GetIssueLevel() == eIssueLevel::ERROR_LVL)
+                        {
+                            error_found = true;
+                        }
                     }
                 }
             }

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -25,7 +25,7 @@
 
 XERCES_CPP_NAMESPACE_USE
 
-static std::map<eIssueLevel, std::string> mapIssueLevelToString = {{eIssueLevel::INFO_LVL, "::notice::"},
+static const std::map<eIssueLevel, std::string> mapIssueLevelToString = {{eIssueLevel::INFO_LVL, "::notice::"},
                                                                    {eIssueLevel::WARNING_LVL, "::warning::"},
                                                                    {eIssueLevel::ERROR_LVL, "::error::"}};
 

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.h
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.h
@@ -31,7 +31,7 @@ class cParameterContainer;
  * @param    [in] argc                Number of arguments in shell
  * @param    [in] argv                Pointer to arguments
  *
- * @return   The standard return value
+ * @return   exit with code 1 is an error was found
  */
 int main(int argc, char *argv[]);
 
@@ -43,8 +43,10 @@ void ShowHelp(const std::string &applicationName);
 
 /** Runs the GitHub CI report using the provided input parameters.
  * @param inputParams The input parameters for the GitHub CI report.
+ *
+ * @return True if an error was found in the results
  */
-void RunGithubCIReport(const cParameterContainer &inputParams);
+bool RunGithubCIReport(const cParameterContainer &inputParams);
 
 /**
  * Writes the default configuration for a report
@@ -60,8 +62,10 @@ void WriteDefaultConfig();
  *
  * @param ptrResultContainer A pointer to the `cResultContainer` object containing the
  *                           checker results.
+ *
+ * @return True if an error was found in the results
  */
-void PrintResults(cResultContainer *ptrResultContainer);
+bool PrintResults(cResultContainer *ptrResultContainer);
 
 /**
  * Adds a prefix to the description of an issue.

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.h
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.h
@@ -9,6 +9,7 @@
 
 #include "common/util.h"
 
+#include <memory>
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/parsers/AbstractDOMParser.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
@@ -60,12 +61,12 @@ void WriteDefaultConfig();
  * and for each checker, it prints the issue level, checker ID, and description for
  * all the issues found by that checker. Thr print format is according to the GitHub CI syntax.
  *
- * @param ptrResultContainer A pointer to the `cResultContainer` object containing the
- *                           checker results.
+ * @param pResultContainer A pointer to the `cResultContainer` object containing the
+ *                         checker results.
  *
  * @return True if an error was found in the results
  */
-bool PrintResults(cResultContainer *ptrResultContainer);
+bool PrintResults(std::unique_ptr<cResultContainer> &pResultContainer);
 
 /**
  * Adds a prefix to the description of an issue.

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.h
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.h
@@ -10,14 +10,6 @@
 #include "common/util.h"
 
 #include <memory>
-#include <xercesc/dom/DOM.hpp>
-#include <xercesc/parsers/AbstractDOMParser.hpp>
-#include <xercesc/parsers/XercesDOMParser.hpp>
-#include <xercesc/sax/ErrorHandler.hpp>
-#include <xercesc/sax/SAXException.hpp>
-#include <xercesc/sax/SAXParseException.hpp>
-#include <xercesc/util/ParseException.hpp>
-#include <xercesc/util/XMLString.hpp>
 
 #include "common/result_format/c_issue.h"
 #include "common/result_format/c_result_container.h"

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.h
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.h
@@ -14,7 +14,7 @@
 #include "common/result_format/c_issue.h"
 #include "common/result_format/c_result_container.h"
 
-#define REPORT_MODULE_NAME "TextReport"
+#define REPORT_MODULE_NAME "GithubCIReport"
 
 class cParameterContainer;
 

--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.h
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 CARIAD SE.
+ * Copyright 2024 BMW AG
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "common/util.h"
+
+#include <xercesc/dom/DOM.hpp>
+#include <xercesc/parsers/AbstractDOMParser.hpp>
+#include <xercesc/parsers/XercesDOMParser.hpp>
+#include <xercesc/sax/ErrorHandler.hpp>
+#include <xercesc/sax/SAXException.hpp>
+#include <xercesc/sax/SAXParseException.hpp>
+#include <xercesc/util/ParseException.hpp>
+#include <xercesc/util/XMLString.hpp>
+
+#include "common/result_format/c_issue.h"
+#include "common/result_format/c_result_container.h"
+
+#define REPORT_MODULE_NAME "TextReport"
+
+class cParameterContainer;
+
+/**
+ * Main function for application
+ *
+ * @param    [in] argc                Number of arguments in shell
+ * @param    [in] argv                Pointer to arguments
+ *
+ * @return   The standard return value
+ */
+int main(int argc, char *argv[]);
+
+/**
+ * Shows the help for the application
+ * @param    [in] applicationName    The name of the application
+ */
+void ShowHelp(const std::string &applicationName);
+
+/** Runs the GitHub CI report using the provided input parameters.
+ * @param inputParams The input parameters for the GitHub CI report.
+ */
+void RunGithubCIReport(const cParameterContainer &inputParams);
+
+/**
+ * Writes the default configuration for a report
+ */
+void WriteDefaultConfig();
+
+/**
+ * Prints the results of the given results container in the GitHub CI format.
+ *
+ * This function iterates over all the checker bundles in the provided `cResultContainer`,
+ * and for each checker, it prints the issue level, checker ID, and description for
+ * all the issues found by that checker. Thr print format is according to the GitHub CI syntax.
+ *
+ * @param ptrResultContainer A pointer to the `cResultContainer` object containing the
+ *                           checker results.
+ */
+void PrintResults(cResultContainer *ptrResultContainer);
+
+/**
+ * Adds a prefix to the description of an issue.
+ * This function takes an issue and prepends the issue ID to the description,
+ * formatting it as "#<issue_id>: <description>".
+ *
+ * @param issueToProcess The issue to update the description for.
+ */
+void AddPrefixForDescriptionIssueProcessor(cChecker *checker, cIssue *issueToProcess);
+

--- a/src/report_modules/report_module_github_ci/src/stdafx.cpp
+++ b/src/report_modules/report_module_github_ci/src/stdafx.cpp
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#include "stdafx.h"

--- a/src/report_modules/report_module_github_ci/src/stdafx.h
+++ b/src/report_modules/report_module_github_ci/src/stdafx.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#ifndef _STD_INCLUDES_HEADER_FEP_XODR_MANIPULATION_
+#define _STD_INCLUDES_HEADER_FEP_XODR_MANIPULATION_
+
+#include <fstream>
+#include <iostream>
+#include <list>
+#include <map>
+#include <memory>
+#include <sstream>
+
+#include "common/util.h"
+
+#endif // _STD_INCLUDES_HEADER_FEP_XODR_MANIPULATION_


### PR DESCRIPTION
**Description**

Add report module to output issues from a report in the GitHub pipeline syntax.


**How was the PR tested?**
I set up a test branch with a CI pipeline giving examples/viewer_example/resources/Result.xqar as an input. You can see the output of the pipeline with the different issue levels (error, warning, info) [here](https://github.com/Persival-GmbH/qc-framework/actions/runs/9712771506).

![image](https://github.com/asam-ev/qc-framework/assets/27010086/3231547d-850b-4cc8-ad1b-92dbbe237e5a)

Fixes #92 