### PR TITLE
Add drag drop action support to report GUI

### DIFF
--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -21,6 +21,8 @@
 #include "common/result_format/c_locations_container.h"
 #include "common/result_format/c_result_container.h"
 
+#include <QDebug>
+#include <QMimeData>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QDesktopWidget>
 #include <QtWidgets/QFileDialog>
@@ -33,6 +35,7 @@
 cReportModuleWindow::cReportModuleWindow(cResultContainer *resultContainer, const std::string &reportModuleName,
                                          QWidget *)
 {
+
     _results = resultContainer;
     _reportModuleName = QString::fromStdString(reportModuleName);
 
@@ -62,6 +65,7 @@ cReportModuleWindow::cReportModuleWindow(cResultContainer *resultContainer, cons
     sourceTabWidget->addTab((QWidget *)_xodrEditorWidget, "OpenDRIVE");
     sourceTabWidget->addTab((QWidget *)_xoscEditorWidget, "OpenSCENARIO");
 
+    sourceTabWidget->setTabEnabled(0, false);
     sourceTabWidget->setTabEnabled(1, false);
 
     xmlReportWidgetLayout->addWidget(xmlReportWidgetLabel);
@@ -263,6 +267,8 @@ cReportModuleWindow::cReportModuleWindow(cResultContainer *resultContainer, cons
     // Set the size of the application of the half size of desktop
     QSize quarterDesktopSize = QDesktopWidget().availableGeometry(this).size() * 0.75f;
     resize(quarterDesktopSize);
+
+    setAcceptDrops(true);
 }
 
 // Loads the result container
@@ -447,5 +453,38 @@ void cReportModuleWindow::closeEvent(QCloseEvent *)
     for (uint32_t i = 0; i < viewerEntries.size(); i++)
     {
         viewerEntries[i]->CloseViewer_f();
+    }
+}
+
+void cReportModuleWindow::dragEnterEvent(QDragEnterEvent *event)
+{
+
+    if (event->mimeData()->hasUrls())
+    {
+        event->acceptProposedAction();
+    }
+}
+
+void cReportModuleWindow::dropEvent(QDropEvent *event)
+{
+    const QMimeData *mimeData = event->mimeData();
+
+    if (mimeData->hasUrls())
+    {
+        QList<QUrl> urlList = mimeData->urls();
+
+        for (const QUrl &url : urlList)
+        {
+            QString filePath = url.toLocalFile();
+            if (!filePath.isNull())
+            {
+                // clear old results
+                _results->Clear();
+                // load new one
+                _results->AddResultsFromXML(filePath.toUtf8().constData());
+
+                LoadResultContainer(_results);
+            }
+        }
     }
 }

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -35,7 +35,6 @@
 cReportModuleWindow::cReportModuleWindow(cResultContainer *resultContainer, const std::string &reportModuleName,
                                          QWidget *)
 {
-
     _results = resultContainer;
     _reportModuleName = QString::fromStdString(reportModuleName);
 

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.h
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.h
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include <QDragEnterEvent>
+#include <QDropEvent>
 #include <QMap>
 #include <QString>
 #include <QtWidgets/QMainWindow>
@@ -66,6 +68,8 @@ class cReportModuleWindow : public QMainWindow
 
     std::vector<std::unique_ptr<Viewer>> viewerEntries;
     Viewer *_viewerActive{nullptr};
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
 
   public:
     cReportModuleWindow() = delete;


### PR DESCRIPTION
**Description**

As mentioned in #23, ReportGUI currently does not support loading result file via drag and drop action
This PR enables the desired behavior

**How was the PR tested?**
1. Unit-test with  sample data. All unit tests passed.

**Notes**
