### PR TITLE
Add extended info to issue description

### DIFF
--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
@@ -726,6 +726,27 @@ void cCheckerWidget::ShowDetails(cIssue *const itemToShow) const
         }
 
         ssDetails << itemToShow->GetIssueLevelStr().c_str() << " | " << itemToShow->GetDescription().c_str();
+        // Add extended informations to description if present
+        std::stringstream extended_info_stream;
+        if (itemToShow->HasLocations())
+        {
+            extended_info_stream << "\n - Extended information:";
+            for (const auto location : itemToShow->GetLocationsContainer())
+            {
+
+                if (location->HasExtendedInformations())
+                {
+                    for (auto xItem : location->GetExtendedInformations())
+                    {
+                        PrintExtendedInformationIntoStream(xItem, &extended_info_stream);
+                    }
+                }
+            }
+        }
+        if (!extended_info_stream.tellp() == std::streampos(0))
+        {
+            ssDetails << extended_info_stream.str().c_str();
+        }
         _issueDetailsTextWidget->setText(result);
     }
 }


### PR DESCRIPTION
**Description**

Addressing from task doc
```
IV. Show domain specific issue location (e.g. Time, RoadLocation) types in the textual description on an issue
```
Add extended info to issue description

**How was the PR tested?**
1. Unit-test with  sample data. All unit tests passed.

**Notes**

Example extended information printed (b
![Screenshot from 2024-07-25 16-04-48](https://github.com/user-attachments/assets/6c2c51f2-f1eb-43b5-9768-80fbdc226493)
ottom)


