### PR TITLE
Only run demo pipeline action on asam-ev organization

### DIFF
--- a/.github/workflows/build-and-push-demo-pipeline.yaml
+++ b/.github/workflows/build-and-push-demo-pipeline.yaml
@@ -1,9 +1,37 @@
 name: Build and push demo pipeline image
 
 on:
-  schedule:
+  # execute on every PR made targeting the branches bellow
+  pull_request:
+    branches:
+      - main
+      - develop # can be removed on main merge
+    paths: # we only include paths critical for building to avoid unnecessary runs
+      - src/**
+      - include/**
+      - scripts/cmake/**
+      - test/**
+      - .github/workflows/**
+      - doc/**
+      - runtime/**
+      - docker/**
+
+  # execute on every push made targeting the branches bellow
+  push:
+    branches:
+      - main
+      - develop # can be removed on main merge
+    paths: # we only include paths critical for building to avoid unnecessary runs
+      - src/**
+      - include/**
+      - scripts/cmake/**
+      - test/**
+      - .github/workflows/**
+      - doc/**
+      - runtime/**
+      - docker/**
+  #schedule:
     #- cron: '0 4 * * *' # 04:00 AM UTC every day
-    - cron: '*/5 * * * *' # TEST every 5 min
 
 jobs:
   build-and-push-demo:

--- a/.github/workflows/build-and-push-demo-pipeline.yaml
+++ b/.github/workflows/build-and-push-demo-pipeline.yaml
@@ -2,43 +2,45 @@ name: Build and push demo pipeline image
 
 on:
   schedule:
-    - cron: '0 4 * * *' # 04:00 AM UTC every day
+    #- cron: '0 4 * * *' # 04:00 AM UTC every day
+    - cron: '*/5 * * * *' # TEST every 5 min
 
 jobs:
   build-and-push-demo:
-    runs-on: ubuntu-22.04
+    if: github.repository_owner == 'asam-ev'
+      runs-on: ubuntu-22.04
 
-    permissions:
-      contents: read
-      packages: write
+      permissions:
+        contents: read
+        packages: write
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: develop # @TODO remove it later
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v3
+          with:
+            ref: develop # @TODO remove it later
 
-      - name: Get current date
-        id: date
-        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+        - name: Get current date
+          id: date
+          run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Log in to GitHub Container Registry
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile.linux
-          push: true
-          target: demo_pipeline
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/qc-framework:demo-pipeline-latest
-            ghcr.io/${{ github.repository_owner }}/qc-framework:demo-pipeline-${{ env.DATE }}
+        - name: Build and push Docker image
+          uses: docker/build-push-action@v6
+          with:
+            context: .
+            file: docker/Dockerfile.linux
+            push: true
+            target: demo_pipeline
+            tags: |
+              ghcr.io/${{ github.repository_owner }}/qc-framework:demo-pipeline-latest
+              ghcr.io/${{ github.repository_owner }}/qc-framework:demo-pipeline-${{ env.DATE }}

--- a/.github/workflows/build-and-push-demo-pipeline.yaml
+++ b/.github/workflows/build-and-push-demo-pipeline.yaml
@@ -1,37 +1,8 @@
 name: Build and push demo pipeline image
 
 on:
-  # execute on every PR made targeting the branches bellow
-  pull_request:
-    branches:
-      - main
-      - develop # can be removed on main merge
-    paths: # we only include paths critical for building to avoid unnecessary runs
-      - src/**
-      - include/**
-      - scripts/cmake/**
-      - test/**
-      - .github/workflows/**
-      - doc/**
-      - runtime/**
-      - docker/**
-
-  # execute on every push made targeting the branches bellow
-  push:
-    branches:
-      - main
-      - develop # can be removed on main merge
-    paths: # we only include paths critical for building to avoid unnecessary runs
-      - src/**
-      - include/**
-      - scripts/cmake/**
-      - test/**
-      - .github/workflows/**
-      - doc/**
-      - runtime/**
-      - docker/**
-  #schedule:
-    #- cron: '0 4 * * *' # 04:00 AM UTC every day
+  schedule:
+    - cron: '0 4 * * *' # 04:00 AM UTC every day
 
 jobs:
   build-and-push-demo:

--- a/.github/workflows/build-and-push-demo-pipeline.yaml
+++ b/.github/workflows/build-and-push-demo-pipeline.yaml
@@ -36,39 +36,39 @@ on:
 jobs:
   build-and-push-demo:
     if: github.repository_owner == 'asam-ev'
-      runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04
 
-      permissions:
-        contents: read
-        packages: write
+    permissions:
+      contents: read
+      packages: write
 
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v3
-          with:
-            ref: develop # @TODO remove it later
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: develop # @TODO remove it later
 
-        - name: Get current date
-          id: date
-          run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+      - name: Get current date
+        id: date
+        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
 
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-        - name: Log in to GitHub Container Registry
-          uses: docker/login-action@v3
-          with:
-            registry: ghcr.io
-            username: ${{ github.repository_owner }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-        - name: Build and push Docker image
-          uses: docker/build-push-action@v6
-          with:
-            context: .
-            file: docker/Dockerfile.linux
-            push: true
-            target: demo_pipeline
-            tags: |
-              ghcr.io/${{ github.repository_owner }}/qc-framework:demo-pipeline-latest
-              ghcr.io/${{ github.repository_owner }}/qc-framework:demo-pipeline-${{ env.DATE }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.linux
+          push: true
+          target: demo_pipeline
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/qc-framework:demo-pipeline-latest
+            ghcr.io/${{ github.repository_owner }}/qc-framework:demo-pipeline-${{ env.DATE }}


### PR DESCRIPTION
**Description**

Add option to execute build_and_push_demo_pipeline action only if github owner is `asam-ev` 

In this way, fork of this repository will not fail when executing the action

**How was the PR tested?**
1. Unit-test with  sample data. All unit tests passed.
2. manually triggered action [here](https://github.com/asam-ev/qc-framework/actions/runs/10096245766/job/27918277373) worked as expected

**Notes**
