### PR TITLE
Fix report modules

### DIFF
--- a/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
+++ b/src/report_modules/report_module_github_ci/src/report_format_github_ci.cpp
@@ -26,8 +26,8 @@
 XERCES_CPP_NAMESPACE_USE
 
 static const std::map<eIssueLevel, std::string> mapIssueLevelToString = {{eIssueLevel::INFO_LVL, "::notice::"},
-                                                                   {eIssueLevel::WARNING_LVL, "::warning::"},
-                                                                   {eIssueLevel::ERROR_LVL, "::error::"}};
+                                                                         {eIssueLevel::WARNING_LVL, "::warning::"},
+                                                                         {eIssueLevel::ERROR_LVL, "::error::"}};
 
 // Main Programm
 int main(int argc, char *argv[])
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
 
     if (StringEndsWith(ToLower(strFilepath), ".xqar"))
     {
-        if (!std::filesystem::exists(strFilepath.c_str()))
+        if (!fs::exists(strFilepath.c_str()))
         {
             std::cerr << "Could not open file '" << strFilepath << "'!" << std::endl
                       << "Abort generating report!" << std::endl;
@@ -103,7 +103,8 @@ int main(int argc, char *argv[])
     }
 
     // Exit with code 1 if an error was found to fail the GitHub pipeline
-    if(RunGithubCIReport(inputParams)) {
+    if (RunGithubCIReport(inputParams))
+    {
         exit(1);
     }
 }
@@ -123,7 +124,6 @@ void ShowHelp(const std::string &toolPath)
     std::cout << "\n\n";
 }
 
-
 bool RunGithubCIReport(const cParameterContainer &inputParams)
 {
     XMLPlatformUtils::Initialize();
@@ -140,7 +140,7 @@ bool RunGithubCIReport(const cParameterContainer &inputParams)
 
         // Add prefix with issue id
         const std::list<cCheckerBundle *> checkerBundles = pResultContainer->GetCheckerBundles();
-        for (auto checkerBundle:  checkerBundles)
+        for (auto checkerBundle : checkerBundles)
         {
             checkerBundle->DoProcessing(AddPrefixForDescriptionIssueProcessor);
         }
@@ -166,26 +166,23 @@ bool PrintResults(std::unique_ptr<cResultContainer> &pResultContainer)
 
     std::list<cCheckerBundle *> bundles = pResultContainer->GetCheckerBundles();
     // Loop over all checker bundles
-    for (auto & bundle : bundles)
+    for (auto &bundle : bundles)
     {
         const auto checkers = bundle->GetCheckers();
 
         // Iterate over all checkers
-        for (auto & checker : checkers)
+        for (auto &checker : checkers)
         {
             // Get all issues from the current checker
             const auto issues = checker->GetIssues();
             if (!issues.empty())
             {
-                for (auto & issue : issues)
+                for (auto &issue : issues)
                 {
                     auto issue_level = mapIssueLevelToString.find(issue->GetIssueLevel());
                     if (issue_level != mapIssueLevelToString.end())
                     {
-                        std::cout << issue_level->second
-                                  << checker->GetCheckerID()
-                                  << ": "
-                                  << issue->GetDescription()
+                        std::cout << issue_level->second << checker->GetCheckerID() << ": " << issue->GetDescription()
                                   << std::endl;
                         if (issue->GetIssueLevel() == eIssueLevel::ERROR_LVL)
                         {
@@ -199,7 +196,6 @@ bool PrintResults(std::unique_ptr<cResultContainer> &pResultContainer)
     return error_found;
 }
 
-
 void AddPrefixForDescriptionIssueProcessor(cChecker *, cIssue *issueToProcess)
 {
     std::stringstream ssDescription;
@@ -207,7 +203,6 @@ void AddPrefixForDescriptionIssueProcessor(cChecker *, cIssue *issueToProcess)
 
     issueToProcess->SetDescription(ssDescription.str());
 }
-
 
 void WriteDefaultConfig()
 {

--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
@@ -159,11 +159,16 @@ cCheckerWidget::cCheckerWidget(QWidget *parent) : QWidget(parent)
     _currentResultContainer = nullptr;
 }
 
-void cCheckerWidget::LoadResultContainer(cResultContainer *const container)
+void cCheckerWidget::UpdateResultContainer(cResultContainer *const container)
 {
     _currentResultContainer = container;
 
     LoadAllItems();
+}
+
+void cCheckerWidget::LoadResultContainer(cResultContainer *const container)
+{
+    UpdateResultContainer(container);
 
     // Show XODR and highlight issues
     if (container->HasCheckerBundles())

--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.h
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.h
@@ -48,6 +48,7 @@ class cCheckerWidget : public QWidget
     cCheckerWidget(QWidget *parent = 0);
 
     void LoadResultContainer(cResultContainer *const container);
+    void UpdateResultContainer(cResultContainer *const container);
 
   protected:
     // Loads a list of cCheckerBundles to the widget view.

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -50,7 +50,6 @@ void cReportModuleWindow::highlightRow(const cIssue *const issue, const int row)
 
 void cReportModuleWindow::loadFileContent(cResultContainer *const container)
 {
-
     QString fileToOpen;
     textEditArea->setPlainText("");
     if (container->HasXODRFileName())
@@ -635,23 +634,28 @@ void cReportModuleWindow::onIssueToggled(bool checked)
 {
     _repetitiveIssueEnabled = checked;
     FilterResultsOnCheckboxes();
-    LoadResultContainer(_results);
+    if (_checkerWidget != nullptr)
+        _checkerWidget->UpdateResultContainer(_results);
 }
 void cReportModuleWindow::onInfoToggled(bool checked)
 {
     _infoLevelEnabled = checked;
     FilterResultsOnCheckboxes();
-    LoadResultContainer(_results);
+    if (_checkerWidget != nullptr)
+        _checkerWidget->UpdateResultContainer(_results);
 }
 void cReportModuleWindow::onWarningToggled(bool checked)
 {
     _warningLevelEnabled = checked;
     FilterResultsOnCheckboxes();
-    LoadResultContainer(_results);
+    if (_checkerWidget != nullptr)
+        _checkerWidget->UpdateResultContainer(_results);
 }
 void cReportModuleWindow::onErrorToggled(bool checked)
 {
     _errorLevelEnabled = checked;
     FilterResultsOnCheckboxes();
-    LoadResultContainer(_results);
+
+    if (_checkerWidget != nullptr)
+        _checkerWidget->UpdateResultContainer(_results);
 }

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -419,6 +419,38 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
 
         ss << "\n" << BASIC_SEPARATOR_LINE << "\n";
 
+        ss << BASIC_SEPARATOR_LINE << "\n";
+
+        ss << "Note"
+           << "\n\n";
+        ss << "Rule UID format:"
+           << "\n";
+        ss << "    <emanating-entity>:<standard>:x.y.z:rule_set.for_rules.rule_name"
+           << "\n\n";
+        ss << "where    "
+           << "\n";
+        ss << "    Emanating Entity: a domain name for the entity (organization or company) that declares the rule UID"
+           << "\n";
+        ss << "    Standard: a short string that represents the standard or the domain to which the rule is applied"
+           << "\n";
+        ss << "    Definition Setting: the version of the standard or the domain to which the rule appears or is "
+              "applied for the first time"
+           << "\n";
+        ss << "    Rule Full Name: the full name of the rule, as dot separated, snake lower case string. "
+           << "\n";
+        ss << "        The full name of a rule is composed by the rule set, a categorization for the rule, "
+           << "\n";
+        ss << "        and the rule name, a unique string inside the categorization. "
+           << "\n";
+        ss << "        The rule set can be nested (meaning that can be defined as an "
+           << "\n";
+        ss << "        arbitrary sequence of dot separated names, while the name is the snake "
+           << "\n";
+        ss << "        case string after the last dot of the full name)"
+           << "\n";
+
+        ss << "\n" << BASIC_SEPARATOR_LINE << "\n";
+
         outFile << ss.rdbuf();
         outFile.close();
     }


### PR DESCRIPTION
**Description**

Added 3 fixes to report module:

- `report_module_gui`: added update logic to result container to avoid loading the input xodr file at every checkbox toggle to fix lagging behavior
- `report_module_text`: add information about rule uid naming schema
- `report_module_github_ci`: fix usage of filesystem library that was causing build error



**How was the PR tested?**
1. Unit-test with  sample data. All unit tests passed.

**Notes**

Checkbox speedup detail. Test was performed by toggling a checbox 4 times
```
Before

[loadFileContent] LOADING FILE....
Checkbox toggle operation duration = 0.962941[s]
[loadFileContent] LOADING FILE....
Checkbox toggle operation duration = 0.914948[s]
[loadFileContent] LOADING FILE....
Checkbox toggle operation duration = 0.920226[s]
[loadFileContent] LOADING FILE....
Checkbox toggle operation duration = 0.92079[s]

Now

[loadFileContent] LOADING FILE....
Checkbox toggle operation duration = 0.253973[s]
Checkbox toggle operation duration = 0.261459[s]
Checkbox toggle operation duration = 0.260521[s]
Checkbox toggle operation duration = 0.271897[s]


```

New text report output, at the end of the txt generated file:

```

Total number of addressed rules:   1
Total number of violated rules:    1
	-> Violated RuleUID: asam.net:xodr:1.7.0:road.geometry.param_poly3.length_match

====================================================================================================

====================================================================================================

Note

Rule UID format:
    <emanating-entity>:<standard>:x.y.z:rule_set.for_rules.rule_name

where    
    Emanating Entity: a domain name for the entity (organization or company) that declares the rule UID
    Standard: a short string that represents the standard or the domain to which the rule is applied
    Definition Setting: the version of the standard or the domain to which the rule appears or is applied for the first time
    Rule Full Name: the full name of the rule, as dot separated, snake lower case string. 
        The full name of a rule is composed by the rule set, a categorization for the rule, 
        and the rule name, a unique string inside the categorization. 
        The rule set can be nested (meaning that can be defined as an 
        arbitrary sequence of dot separated names, while the name is the snake 
        case string after the last dot of the full name)

====================================================================================================


```