### PR TITLE
Fix result pooling file locations

### DIFF
--- a/demo_pipeline/templates/otx_template.xml
+++ b/demo_pipeline/templates/otx_template.xml
@@ -5,8 +5,10 @@
 
     <CheckerBundle application="otxBundle">
         <Param name="resultFile" value="otx_bundle_report.xqar" />
-        <Checker checkerId="basic_otx" maxLevel="1" minLevel="3" />
+        <Checker checkerId="core_otx" maxLevel="1" minLevel="3" />
         <Checker checkerId="data_type_otx" maxLevel="1" minLevel="3" />
+        <Checker checkerId="zip_file_otx" maxLevel="1" minLevel="3" />
+        <Checker checkerId="state_machine_otx" maxLevel="1" minLevel="3" />
     </CheckerBundle>
 
     <ReportModule application="TextReport">

--- a/demo_pipeline/templates/xodr_template.xml
+++ b/demo_pipeline/templates/xodr_template.xml
@@ -7,6 +7,7 @@
         <Param name="resultFile" value="xodr_bundle_report.xqar" />
         <Checker checkerId="semantic_xodr" maxLevel="1" minLevel="3" />
         <Checker checkerId="geometry_xodr" maxLevel="1" minLevel="3" />
+        <Checker checkerId="performance_checker" maxLevel="1" minLevel="3" />
     </CheckerBundle>
 
     <ReportModule application="TextReport">

--- a/demo_pipeline/templates/xodr_template.xml
+++ b/demo_pipeline/templates/xodr_template.xml
@@ -7,7 +7,7 @@
         <Param name="resultFile" value="xodr_bundle_report.xqar" />
         <Checker checkerId="semantic_xodr" maxLevel="1" minLevel="3" />
         <Checker checkerId="geometry_xodr" maxLevel="1" minLevel="3" />
-        <Checker checkerId="performance_checker" maxLevel="1" minLevel="3" />
+        <Checker checkerId="performance_xodr" maxLevel="1" minLevel="3" />
     </CheckerBundle>
 
     <ReportModule application="TextReport">

--- a/demo_pipeline/templates/xosc_template.xml
+++ b/demo_pipeline/templates/xosc_template.xml
@@ -10,7 +10,6 @@
         <Checker checkerId="data_type_xosc" maxLevel="1" minLevel="3" />
         <Checker checkerId="parameters_xosc" maxLevel="1" minLevel="3" />
         <Checker checkerId="reference_xosc" maxLevel="1" minLevel="3" />
-        <Checker checkerId="schema_xosc" maxLevel="1" minLevel="3" />
     </CheckerBundle>
 
     <ReportModule application="TextReport">

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -37,12 +37,12 @@ void cReportModuleWindow::highlightRow(const cIssue *const issue, const int row)
 
     if (highlighter)
     {
-        highlighter->setLineToHighlight(row);
+        highlighter->setLineToHighlight(row - 1);
         textEditArea->update();
         // Move cursor to the highlighted row and center it
         QTextCursor cursor = textEditArea->textCursor();
         cursor.movePosition(QTextCursor::Start);
-        cursor.movePosition(QTextCursor::Down, QTextCursor::MoveAnchor, row);
+        cursor.movePosition(QTextCursor::Down, QTextCursor::MoveAnchor, row - 1);
         textEditArea->setTextCursor(cursor);
         textEditArea->centerCursor();
     }

--- a/src/result_pooling/src/result_pooling.cpp
+++ b/src/result_pooling/src/result_pooling.cpp
@@ -44,6 +44,7 @@ int main(int argc, char *argv[])
 {
     XMLPlatformUtils::Initialize();
 
+    QCoreApplication app(argc, argv);
     std::vector<std::string> args(argv, argv + argc);
     std::string strToolpath = args[0];
 


### PR DESCRIPTION
**Description**

- Ensure Xpath to FileLocation is enabled in ResultPooling
- Update demo pipeline templates to list all checkers there
- Remove qt warnings when executing ResultPooling locally 
- Fix line highlighting, previous logic was always highlighting the (issueLocation + 1)-th row

**How was the PR tested?**
1. Unit-test with  sample data. All unit tests passed.

**Notes**
