### PR TITLE
Remove an outdated requirement

### DIFF
--- a/doc/manual/architecture.md
+++ b/doc/manual/architecture.md
@@ -141,7 +141,6 @@ flowchart LR
 - Checker Bundle
   - Runs probably only on certain platforms, because a third party product
     is not available for all platforms
-  - Must be able to print out to the command line which Checkers are included
 - Result Pooling
   - Summarizes all results (overview and detailed view possible)
   - Gives each incident a unique Id → assignment results in different report


### PR DESCRIPTION
**Description**

In the current state of the architecture, Checker Bundles do not need to print out to the command line which checkers are included. The information can be generated directly to a markdown file for documentation purpose. In the future, such information can be included in the manifest file for automatic integration with the framework.

**Main changes**
1. Remove the outdated requirement

**How was the PR tested?**
1. Render locally.

**Notes**

Related issue
* #38 