### PR TITLE
Add esmini viewer plugin example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 add_subdirectory(checker_bundle_example)
 add_subdirectory(viewer_example)
+add_subdirectory(esmini_viewer)
 
 install(
     DIRECTORY

--- a/examples/esmini_viewer/CMakeLists.txt
+++ b/examples/esmini_viewer/CMakeLists.txt
@@ -33,8 +33,5 @@ install(
         examples/esmini_viewer/src
 )
 
-target_compile_definitions(${VIEWER}
-    PRIVATE INSTALL_NAME_DIR_BIN_DIR="${CMAKE_INSTALL_PREFIX}/bin"
-)
 
 set_target_properties(${VIEWER} PROPERTIES FOLDER examples/viewer)

--- a/examples/esmini_viewer/CMakeLists.txt
+++ b/examples/esmini_viewer/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright 2023 CARIAD SE.
+#
+# This Source Code Form is subject to the terms of the Mozilla
+# Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR) # CMake policy CMP0095
+cmake_policy(SET CMP0095 NEW) # RPATH entries are properly escaped in the intermediary CMake install script
+
+set(VIEWER EsminiViewer)
+project(${VIEWER})
+
+set(CMAKE_INSTALL_RPATH $ORIGIN/../../lib)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS true)
+
+include_directories(${VIEWER} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/report_modules/report_module_gui/src
+)
+
+add_library(${VIEWER} SHARED esmini_viewer.cpp helper.cpp)
+target_link_libraries(${VIEWER} PRIVATE qc4openx-common $<$<PLATFORM_ID:Linux>:stdc++fs>)
+
+install(
+    TARGETS ${VIEWER}
+    DESTINATION bin/plugin
+)
+
+install(
+    FILES
+    esmini_viewer.cpp
+    DESTINATION
+        examples/esmini_viewer/src
+)
+
+target_compile_definitions(${VIEWER}
+    PRIVATE INSTALL_NAME_DIR_BIN_DIR="${CMAKE_INSTALL_PREFIX}/bin"
+)
+
+set_target_properties(${VIEWER} PROPERTIES FOLDER examples/viewer)

--- a/examples/esmini_viewer/README.md
+++ b/examples/esmini_viewer/README.md
@@ -1,0 +1,28 @@
+# Esmini viewer plugin
+
+This folder contain the plugin to add an odr viewer based on esmini-odrviewer application
+
+## Installation
+
+After building the framework, a new plugin will be shown in the `File` dropdown menu of the ReportGUI application
+
+The plugin executes the command
+
+```
+odrviewer --density 0 --window 100 100 800 800 --odr YOUR_ODR
+```
+
+So in order to execute this you need to
+
+1. Download esmini-demo from [esmini release page](https://github.com/esmini/esmini/releases)
+2. Copy the `odrviewer` executable from the `esmini-demo/bin` directory to your install directory, where the ReportGUI executable is also generated
+
+## Usage
+
+The plugin checks the input file pointed by the xqar file you are inspecting:
+
+- If it is an OTX file, the plugin does not show anything
+- If it is an ODR file, the plugin shows it
+- If it is an OSC file, the plugin get the correspoding openDRIVE file from the input openSCENARIO and shows that road network
+
+Currently the plugin has only the functionality of showing the road network and it is presented for demonstration purposes.

--- a/examples/esmini_viewer/README.md
+++ b/examples/esmini_viewer/README.md
@@ -15,7 +15,20 @@ odrviewer --density 0 --window 100 100 800 800 --odr YOUR_ODR
 So in order to execute this you need to
 
 1. Download esmini-demo from [esmini release page](https://github.com/esmini/esmini/releases)
-2. Copy the `odrviewer` executable from the `esmini-demo/bin` directory to your install directory, where the ReportGUI executable is also generated
+2. Install `odrviewer` in your system path
+
+    - Linux install
+        Long term installation:
+
+        ```
+        sudo mv esmini-demo/bin/odrviewer /usr/local/bin/
+        ```
+
+        Short term installation:
+
+        ```
+        export PATH=$PATH:esmini-demo/bin/
+        ```
 
 ## Usage
 

--- a/examples/esmini_viewer/esmini_viewer.cpp
+++ b/examples/esmini_viewer/esmini_viewer.cpp
@@ -45,6 +45,16 @@ bool Initialize(const char *inputPath)
         lasterrormsg = "ERROR: No valid xosc or xodr file found.";
         return false;
     }
+
+    bool viewerAvailable = IsExecutableAvailable("odrviewer");
+
+    if (!viewerAvailable)
+    {
+        lasterrormsg = "ERROR: Odrivewer executable not found in system path. Please follow "
+                       "qc-framework/examples/esmini_viewer/README.md for install instructions";
+        return false;
+    }
+
     std::cout << "INITILAIZE VIEWER WITH INPUT FILE: " << inputPath << std::endl;
     std::string strResultMessage;
     std::string inputFileExtension = getFileExtension(inputPath);
@@ -77,28 +87,21 @@ bool Initialize(const char *inputPath)
 
 bool AddIssue(void *issueToAdd)
 {
-    auto issue = static_cast<cIssue *>(issueToAdd);
-    std::cout << "ADD ISSUE: " << issue->GetDescription() << std::endl;
     return true;
 }
 
 bool ShowIssue(void *itemToShow, void *locationToShow)
 {
-    auto issue = static_cast<cIssue *>(itemToShow);
-    auto location = static_cast<cLocationsContainer *>(locationToShow);
-    std::cout << "SHOW ISSUE: " << issue->GetDescription() << std::endl;
-    std::cout << "LOCATION: " << location->GetDescription() << std::endl;
     return true;
 }
 
 const char *GetName()
 {
-    return "Odr Viewer based on esmini-odrviewer";
+    return "Esmini Viewer";
 }
 
 bool CloseViewer()
 {
-    std::cout << "CLOSE VIEWER EXAMPLE" << std::endl;
     return true;
 }
 

--- a/examples/esmini_viewer/esmini_viewer.cpp
+++ b/examples/esmini_viewer/esmini_viewer.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "common/result_format/c_issue.h"
+#include "common/result_format/c_locations_container.h"
+#include "common/util.h"
+#include "helper.h"
+#include "viewer/i_connector.h"
+#include <cstring>
+#include <stdio.h>
+
+const char *lasterrormsg = "";
+
+bool StartViewer()
+{
+    std::cout << "START Odr Viewer" << std::endl;
+    return true;
+}
+
+std::string getFileExtension(const std::string &filename)
+{
+    // Find the last occurrence of the dot character in the filename
+    size_t dotPosition = filename.rfind('.');
+
+    // Check if a dot was found and it's not the first character
+    if (dotPosition != std::string::npos && dotPosition != 0)
+    {
+        return filename.substr(dotPosition + 1); // Return the extension without the dot
+    }
+    else
+    {
+        return ""; // No valid extension found
+    }
+}
+
+bool Initialize(const char *inputPath)
+{
+    if (std::strcmp(inputPath, "") == 0)
+    {
+        lasterrormsg = "ERROR: No valid xosc or xodr file found.";
+        return false;
+    }
+    std::cout << "INITILAIZE VIEWER WITH INPUT FILE: " << inputPath << std::endl;
+    std::string strResultMessage;
+    std::string inputFileExtension = getFileExtension(inputPath);
+
+    std::string odrToShow;
+    if (inputFileExtension == "otx")
+    {
+        lasterrormsg = "ERROR: Cannot load otx file in odr viewer";
+        return false;
+    }
+    else if (inputFileExtension == "xosc")
+    {
+        bool result = GetXodrFilePathFromXosc(inputPath, odrToShow);
+        if (not result)
+        {
+            lasterrormsg = "ERROR: Cannot retrieve odr from input xosc";
+            return false;
+        }
+    }
+    else if (inputFileExtension == "xodr")
+    {
+        odrToShow = inputPath;
+    }
+    std::cout << "odrToShow : " << odrToShow << std::endl;
+    bool result = ExecuteCommand(strResultMessage, "odrviewer",
+                                 "--density 0 --window 100 100 800 800 --odr " + std::string(odrToShow));
+    std::cout << strResultMessage << std::endl;
+    return result;
+}
+
+bool AddIssue(void *issueToAdd)
+{
+    auto issue = static_cast<cIssue *>(issueToAdd);
+    std::cout << "ADD ISSUE: " << issue->GetDescription() << std::endl;
+    return true;
+}
+
+bool ShowIssue(void *itemToShow, void *locationToShow)
+{
+    auto issue = static_cast<cIssue *>(itemToShow);
+    auto location = static_cast<cLocationsContainer *>(locationToShow);
+    std::cout << "SHOW ISSUE: " << issue->GetDescription() << std::endl;
+    std::cout << "LOCATION: " << location->GetDescription() << std::endl;
+    return true;
+}
+
+const char *GetName()
+{
+    return "Odr Viewer based on esmini-odrviewer";
+}
+
+bool CloseViewer()
+{
+    std::cout << "CLOSE VIEWER EXAMPLE" << std::endl;
+    return true;
+}
+
+const char *GetLastErrorMessage()
+{
+    return lasterrormsg;
+}

--- a/examples/esmini_viewer/helper.cpp
+++ b/examples/esmini_viewer/helper.cpp
@@ -8,18 +8,27 @@
 
 #include "helper.h"
 
+bool IsExecutableAvailable(const std::string &executable)
+{
+#ifdef _WIN32
+    std::string command = "where " + executable + " > nul 2>&1";
+#else
+    std::string command = "which " + executable + " > /dev/null 2>&1";
+#endif
+
+    return std::system(command.c_str()) == 0;
+}
+
 bool ExecuteCommand(std::string &strResultMessage, std::string strCommand, const std::string strArgument)
 {
-    std::string strInstallDir = std::string(INSTALL_NAME_DIR_BIN_DIR);
-    strInstallDir.append("/");
-    std::string strTotalCommand = strInstallDir;
+    std::string strTotalCommand = "";
 
 #ifdef WIN32
     strCommand.append(".exe");
 #endif
     strTotalCommand.append(strCommand.c_str());
 
-    if (fs::exists(strTotalCommand))
+    if (IsExecutableAvailable(strCommand))
     {
         if (!strArgument.empty())
         {

--- a/examples/esmini_viewer/helper.cpp
+++ b/examples/esmini_viewer/helper.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "helper.h"
+
+bool ExecuteCommand(std::string &strResultMessage, std::string strCommand, const std::string strArgument)
+{
+    std::string strInstallDir = std::string(INSTALL_NAME_DIR_BIN_DIR);
+    strInstallDir.append("/");
+    std::string strTotalCommand = strInstallDir;
+
+#ifdef WIN32
+    strCommand.append(".exe");
+#endif
+    strTotalCommand.append(strCommand.c_str());
+
+    if (fs::exists(strTotalCommand))
+    {
+        if (!strArgument.empty())
+        {
+            strTotalCommand.append(" ");
+            strTotalCommand.append(strArgument.c_str());
+        }
+
+        int32_t i32Res = system(strTotalCommand.c_str());
+        if (i32Res != 0)
+        {
+            strResultMessage =
+                "Command executed with result " + std::to_string(i32Res) + ". Command: '" + strTotalCommand + "'.";
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    strResultMessage =
+        "Command to execute was not found in any defined install directory. Command: '" + strTotalCommand + "'.";
+    return false;
+}

--- a/examples/esmini_viewer/helper.h
+++ b/examples/esmini_viewer/helper.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#ifndef _HELPER_HEADER_
+#define _HELPER_HEADER_
+
+#include "qc4openx_filesystem.h"
+
+bool ExecuteCommand(std::string &strResultMessage, std::string strCommand, const std::string strArgument = "");
+
+#endif

--- a/examples/esmini_viewer/helper.h
+++ b/examples/esmini_viewer/helper.h
@@ -10,6 +10,7 @@
 
 #include "qc4openx_filesystem.h"
 
+bool IsExecutableAvailable(const std::string &executable);
 bool ExecuteCommand(std::string &strResultMessage, std::string strCommand, const std::string strArgument = "");
 
 #endif

--- a/examples/esmini_viewer/qc4openx_filesystem.h
+++ b/examples/esmini_viewer/qc4openx_filesystem.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2023 CARIAD SE.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef QC4OPENX_FILESYSTEM_H_
+#define QC4OPENX_FILESYSTEM_H_
+
+#ifdef __has_include
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+#else
+#error __has_include is not defined, but is needed to detect correct filesystem!
+#endif
+
+#endif


### PR DESCRIPTION
**Description**

Add  the plugin to add an odr viewer based on esmini-odrviewer application


**How was the PR tested?**
1. Unit-test with  sample data. All unit tests passed.

**Notes**
Example of the viewer showing an XODR associated with the XOSC file pointed by the xqar file under analysis

![Screenshot from 2024-08-23 11-52-27](https://github.com/user-attachments/assets/20eeb4aa-22eb-461d-8627-20185da587cf)
