### PR TITLE
runtime: Support optional argument to specify working dir

### DIFF
--- a/demo_pipeline/run_pipeline.sh
+++ b/demo_pipeline/run_pipeline.sh
@@ -5,11 +5,11 @@
 
 python3 /app/demo_pipeline/configuration_generator.py
 
+OUTPUT_DIR=/out/qc-result-$INPUT_FILENAME
+
 qc_runtime \
     --config "/tmp/generated_config/config.xml" \
-    --manifest "/app/demo_pipeline/manifests/framework_manifest.json"
+    --manifest "/app/demo_pipeline/manifests/framework_manifest.json" \
+    --working_dir "$OUTPUT_DIR"
 
-mkdir -p /out/qc-result-$INPUT_FILENAME
-cp /app/framework/bin/*.xqar /out/qc-result-$INPUT_FILENAME
-cp /app/framework/bin/*.txt /out/qc-result-$INPUT_FILENAME
-chown -R $USER_ID:$GROUP_ID /out/qc-result-$INPUT_FILENAME
+chown -R $USER_ID:$GROUP_ID $OUTPUT_DIR

--- a/demo_pipeline/templates/otx_template.xml
+++ b/demo_pipeline/templates/otx_template.xml
@@ -4,7 +4,7 @@
     <Param name="InputFile" value="test.otx" />
 
     <CheckerBundle application="otxBundle">
-        <Param name="resultFile" value="/app/framework/bin/otx_bundle_report.xqar" />
+        <Param name="resultFile" value="otx_bundle_report.xqar" />
         <Checker checkerId="core_otx" maxLevel="1" minLevel="3" />
         <Checker checkerId="data_type_otx" maxLevel="1" minLevel="3" />
         <Checker checkerId="zip_file_otx" maxLevel="1" minLevel="3" />
@@ -13,7 +13,7 @@
 
     <ReportModule application="TextReport">
         <Param name="strInputFile" value="Result.xqar" />
-        <Param name="strReportFile" value="/app/framework/bin/Report.txt" />
+        <Param name="strReportFile" value="Report.txt" />
     </ReportModule>
 
 </Config>

--- a/demo_pipeline/templates/xodr_template.xml
+++ b/demo_pipeline/templates/xodr_template.xml
@@ -4,7 +4,7 @@
     <Param name="InputFile" value="test.xodr" />
 
     <CheckerBundle application="xodrBundle">
-        <Param name="resultFile" value="/app/framework/bin/xodr_bundle_report.xqar" />
+        <Param name="resultFile" value="xodr_bundle_report.xqar" />
         <Checker checkerId="semantic_xodr" maxLevel="1" minLevel="3" />
         <Checker checkerId="geometry_xodr" maxLevel="1" minLevel="3" />
         <Checker checkerId="performance_xodr" maxLevel="1" minLevel="3" />
@@ -12,7 +12,7 @@
 
     <ReportModule application="TextReport">
         <Param name="strInputFile" value="Result.xqar" />
-        <Param name="strReportFile" value="/app/framework/bin/Report.txt" />
+        <Param name="strReportFile" value="Report.txt" />
     </ReportModule>
 
 </Config>

--- a/demo_pipeline/templates/xosc_template.xml
+++ b/demo_pipeline/templates/xosc_template.xml
@@ -4,7 +4,7 @@
     <Param name="InputFile" value="template.xosc" />
 
     <CheckerBundle application="xoscBundle">
-        <Param name="resultFile" value="/app/framework/bin/xosc_bundle_report.xqar" />
+        <Param name="resultFile" value="xosc_bundle_report.xqar" />
         <Checker checkerId="basic_xosc" maxLevel="1" minLevel="3" />
         <Checker checkerId="schema_xosc" maxLevel="1" minLevel="3" />
         <Checker checkerId="data_type_xosc" maxLevel="1" minLevel="3" />
@@ -14,7 +14,7 @@
 
     <ReportModule application="TextReport">
         <Param name="strInputFile" value="Result.xqar" />
-        <Param name="strReportFile" value="/app/framework/bin/Report.txt" />
+        <Param name="strReportFile" value="Report.txt" />
     </ReportModule>
 
 </Config>

--- a/doc/manual/runtime_module.md
+++ b/doc/manual/runtime_module.md
@@ -29,3 +29,11 @@ where
 
 - `$PATH_TO_CONFIG_FILE` points to an xml file following the [config xsd schema](../doc/schema/config_format.xsd)
 - `$PATH_TO_MANIFEST_FILE` points to the [manifest file](manifest_file.md) of the framework.
+
+All the files generated during the runtime execution, including result files and report files, will be saved in the output folder `qc-output-YYYY-MM-DD-HH-MM-SS-*`.
+
+Alternatively, users can specify a specific output folder for the runtime using the argument `--working_dir`.
+
+```bash
+qc_runtime --config=$PATH_TO_CONFIG_FILE --manifest=$PATH_TO_MANIFEST_FILE --working_dir=$PATH_TO_OUTPUT_FOLDER
+```

--- a/runtime/runtime/runtime.py
+++ b/runtime/runtime/runtime.py
@@ -106,13 +106,14 @@ def execute_modules(
         run_module_command(report_module, config_file_path, output_path)
 
 
-def execute_runtime(config_file_path: str, manifest_file_path: str) -> None:
+def execute_runtime(config_file_path: str, manifest_file_path: str, working_dir: str) -> None:
     """Execute all runtime operations defined in the input manifest over the
     defined configuration.
 
     Args:
         config_file_path (str): input configuration xml file path
         manifest_file_path (str): input manifest json file path
+        working_dir (str): working directory
     """
 
     checker_bundles = {}
@@ -157,16 +158,12 @@ def execute_runtime(config_file_path: str, manifest_file_path: str) -> None:
             f"No result pooling module found in the provided framework manifest. There must be exactly one result pooling module defined."
         )
 
-    formatted_now = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S_%f")
-    execution_output_path = os.path.join(os.getcwd(), formatted_now)
-    os.makedirs(execution_output_path, exist_ok=True)
-
     execute_modules(
         config_file_path,
         checker_bundles,
         result_pooling,
         report_modules,
-        execution_output_path,
+        working_dir,
     )
 
 
@@ -185,9 +182,25 @@ def main():
         required=True,
     )
 
+    parser.add_argument(
+        "--working_dir",
+        type=str,
+        help="Working directory where all the output files are generated.",
+        required=False,
+    )
+
     args = parser.parse_args()
 
-    execute_runtime(args.config, args.manifest)
+    working_dir = None
+    if args.working_dir is None:
+        formatted_now = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S_%f")
+        working_dir = os.path.join(os.getcwd(), f"qc-output-{formatted_now}")
+    else:
+        working_dir = os.path.abspath(args.working_dir)
+
+    os.makedirs(working_dir, exist_ok=True)
+
+    execute_runtime(args.config, args.manifest, working_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description**

Support the optional argument `--working_dir` for the runtime module. The argument is useful for automated integration with other tools.

**Main changes**
1. Add `--working_dir` as an optional argument to the runtime module.
2. Change the default output folder to `qc-output-YYYY-MM-DD-...`
3. Remove all the absolute path in the template config file of the demo pipeline.
4. Update the workflow of the demo pipeline with the `--working_dir` arg.
5. Update runtime module documentation.

**How was the PR tested?**
1. Tested using the demo pipeline locally.

**Notes**
