### PR TITLE
Update build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,15 @@ The ASAM Quality Checker Framework runs on Linux and Windows. The framework cons
 Links to download the sources and the tested versions can be found in the
 [license information appendix](licenses/readme.md).
 
+## Build and install C++ modules
+
+- Use CMakeLists.txt within the main directory as source directory
+- Do not forget to set `CMAKE_INSTALL_PREFIX`
+- Do not forget to set `CMAKE_BUILD_TYPE` if using CMake generator `Unix
+  Makefiles`
+
+### Build on Linux
+
 On Linux, toolchain and 3rd party dependencies can be installed as follows (example for Ubuntu 22.04).
 
 ```bash
@@ -44,14 +53,7 @@ apt update && apt install -y \
     git
 ```
 
-## Build and install C++ modules
-
-- Use CMakeLists.txt within the main directory as source directory
-- Do not forget to set `CMAKE_INSTALL_PREFIX`
-- Do not forget to set `CMAKE_BUILD_TYPE` if using CMake generator `Unix
-  Makefiles`
-
-For Linux, an example CMake call to build the framework
+An example CMake call to build the framework
 looks like this (call from the repository root):
 
 ```bash
@@ -64,6 +66,22 @@ cmake --build ./build --target install --config Release -j4
 cmake --install ./build
 ```
 
+### Build on Windows
+
+On Windows, an example build for the the dependency XercesC looks like this:
+
+```bash
+$xercesZip = "$env:WORKING_PATH\xerces-c-3.2.5.zip"
+Invoke-WebRequest -Uri "https://dlcdn.apache.org/xerces/c/3/sources/xerces-c-3.2.5.zip" -OutFile $xercesZip
+Expand-Archive -Path $xercesZip -DestinationPath "$env:WORKING_PATH"
+cd "$env:WORKING_PATH\xerces-c-3.2.5"
+mkdir build
+cd build
+cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX="$env:WORKING_PATH\Xerces-Out" ..
+cmake --build . --config Debug
+cmake --build . --config Debug --target install
+```
+
 For Windows Visual Studio 16 2019 an example CMake call to build the framework
 looks like this (call from the repository root):
 
@@ -73,9 +91,8 @@ $ cmake -G "Visual Studio 16 2019" -A "x64" -T "v142" -B../build -S. ^
     -DCMAKE_INSTALL_PREFIX="<prefix>" ^
     -DENABLE_FUNCTIONAL_TESTS=ON ^
     -DGTest_ROOT="<gtest_root>" ^ 
-    -DASAM_OPENDRIVE_XSD_DIR="<asam_opendrive_xsd_dir>" ^
-    -DASAM_OPENSCENARIO_XSD_DIR="<asam_openscenario_xsd_dir>" ^
-    -DQt5_ROOT="<qt5_root>"
+    -DQt5_ROOT="<qt5_root>" ^
+    -DXercesC_ROOT="<xerces_c_root>"
 $ cmake --build ../build --target ALL_BUILD --config Release
 $ ctest --test-dir ../build -C Release
 $ cmake --install ../build
@@ -85,12 +102,6 @@ With the following CMake values:
 
 - _\<prefix\>_: The prefix CMake installs the package to
 - _\<GTest_ROOT\>_: The root dir of the pre-built GoogleTest package
-- _\<asam_opendrive_xsd_dir\>_: The directory containing the schema (*.xsd)
-  files for OpenDRIVE downloaded from the ASAM website (multiple versions of
-  the schema files in this directory are supported).
-- _\<asam_openscenario_xsd_dir\>_: The directory containing the schema (*.xsd)
-  files for OpenSCENARIO downloaded from the ASAM website (multiple versions of
-  the schema files in this directory are supported).
 - _\<xerces_c_root\>_: The root dir of the pre-built Xerces-C++ package
 - _\<Qt5_ROOT\>_: The root dir of the pre-built qt5 package
 


### PR DESCRIPTION
**Description**

Update the build instructions on Linux and Windows to include example of XercesC build and remove outdated CMake argument.

**Main changes**
1. Restructure build instructions
2. Add example XercesC build command on Windows
3. Remove outdated CMake arguments on build command on Windows.

**How was the PR tested?**
1. Render locally. The build commands are compared with the automated build on GitHub Action.

**Notes**

Fix https://github.com/asam-ev/qc-framework/issues/139