### PR TITLE
Add relative rule uid to report modules

### DIFF
--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
@@ -727,6 +727,12 @@ void cCheckerWidget::ShowDetails(cIssue *const itemToShow) const
         }
 
         ssDetails << itemToShow->GetIssueLevelStr().c_str() << " | " << itemToShow->GetDescription().c_str();
+        if (itemToShow->GetRuleUID() != "")
+        {
+            ssDetails << "\nRelative to ruleUID: ";
+            ssDetails << itemToShow->GetRuleUID().c_str();
+        }
+
         // Add extended informations to description if present
         std::stringstream extended_info_stream;
         if (itemToShow->HasLocations())

--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
@@ -729,7 +729,7 @@ void cCheckerWidget::ShowDetails(cIssue *const itemToShow) const
         ssDetails << itemToShow->GetIssueLevelStr().c_str() << " | " << itemToShow->GetDescription().c_str();
         if (itemToShow->GetRuleUID() != "")
         {
-            ssDetails << "\nRelative to ruleUID: ";
+            ssDetails << "\nruleUID: ";
             ssDetails << itemToShow->GetRuleUID().c_str();
         }
 

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -349,7 +349,7 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
                         if ((*it_Issue)->GetRuleUID() != "")
                         {
                             ss << "\n                       "
-                               << "Relative to ruleUID: " << (*it_Issue)->GetRuleUID();
+                               << "ruleUID: " << (*it_Issue)->GetRuleUID();
                         }
 
                         PrintExtendedInformationIntoStream((*it_Issue), &ss);
@@ -499,8 +499,10 @@ void PrintExtendedInformationIntoStream(cIssue *issue, std::stringstream *ssStre
 {
     for (const auto location : issue->GetLocationsContainer())
     {
-        *ssStream << "\n                    " << location->GetDescription();
-
+        if (location->GetDescription() != "")
+        {
+            *ssStream << "\n                    " << location->GetDescription();
+        }
         std::list<cExtendedInformation *> extendedInfos = location->GetExtendedInformations();
 
         for (std::list<cExtendedInformation *>::iterator extIt = extendedInfos.begin(); extIt != extendedInfos.end();

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -260,7 +260,9 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
     std::list<cIssue *> issues;
     std::list<cRule *> rules;
     std::list<cMetadata *> metadata;
-    std::set<std::string> violated_rules;
+    std::set<std::string> info_violated_rules;
+    std::set<std::string> warning_violated_rules;
+    std::set<std::string> error_violated_rules;
     std::set<std::string> addressed_rules;
 
     if (outFile.is_open())
@@ -353,7 +355,19 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
                         PrintExtendedInformationIntoStream((*it_Issue), &ss);
                         if ((*it_Issue)->GetRuleUID() != "")
                         {
-                            violated_rules.insert((*it_Issue)->GetRuleUID());
+                            eIssueLevel current_issue_level = (*it_Issue)->GetIssueLevel();
+                            if (current_issue_level == eIssueLevel::INFO_LVL)
+                            {
+                                info_violated_rules.insert((*it_Issue)->GetRuleUID());
+                            }
+                            if (current_issue_level == eIssueLevel::WARNING_LVL)
+                            {
+                                warning_violated_rules.insert((*it_Issue)->GetRuleUID());
+                            }
+                            if (current_issue_level == eIssueLevel::ERROR_LVL)
+                            {
+                                error_violated_rules.insert((*it_Issue)->GetRuleUID());
+                            }
                         }
                         if ((*it_Issue)->HasDomainSpecificInfo())
                         {
@@ -414,10 +428,24 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
             ss << "\n\t-> Addressed RuleUID: " << str << "\n";
         }
 
-        ss << "\nTotal number of violated rules:    " << violated_rules.size();
-        for (const auto &str : violated_rules)
+        int total_number_of_violated_rules =
+            info_violated_rules.size() + warning_violated_rules.size() + error_violated_rules.size();
+        ss << "\nTotal number of violated rules:    " << total_number_of_violated_rules << "\n";
+
+        ss << "\nInfo violated rules:               " << info_violated_rules.size();
+        for (const auto &str : info_violated_rules)
         {
-            ss << "\n\t-> Violated RuleUID: " << str << "\n";
+            ss << "\n\t-> Info violation RuleUID: " << str;
+        }
+        ss << "\nWarning violated rules:            " << warning_violated_rules.size();
+        for (const auto &str : warning_violated_rules)
+        {
+            ss << "\n\t-> Warning violation RuleUID: " << str;
+        }
+        ss << "\nError violated rules:              " << error_violated_rules.size();
+        for (const auto &str : error_violated_rules)
+        {
+            ss << "\n\t-> Error violation RuleUID: " << str;
         }
 
         ss << "\n" << BASIC_SEPARATOR_LINE << "\n";

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -344,6 +344,12 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
                         ss << "\n        " << mapIssueLevelToString[(*it_Issue)->GetIssueLevel()]
                            << (*it_Issue)->GetDescription();
 
+                        if ((*it_Issue)->GetRuleUID() != "")
+                        {
+                            ss << "\n                       "
+                               << "Relative to ruleUID: " << (*it_Issue)->GetRuleUID();
+                        }
+
                         PrintExtendedInformationIntoStream((*it_Issue), &ss);
                         if ((*it_Issue)->GetRuleUID() != "")
                         {


### PR DESCRIPTION
**Description**

Addressing #160  and https://github.com/asam-ev/qc-opendrive/issues/91, Add rule uid information to report modules

Text report example

```
 Checker:        performance_xodr
    Description:    Evaluates elements in the file to guarantee they are optimized.
    Status:         completed
    Summary:        
        Warning:    #3: Redudant line geometry declaration.
                       ruleUID: asam.net:xodr:1.7.0:performance.avoid_redundant_info
                       XPath: /OpenDRIVE/road[3]
                    Redundant line geometry declaration.
                       Location: x=228.68 y=96.2411 z=1
```

ReportGUI example
![image](https://github.com/user-attachments/assets/84fc905a-8375-43b9-b5ce-8a0f6903dae3)

In TextReport also addressed #162 

Example output

```
Total number of addressed rules:   1
Total number of violated rules:    1

Info violated rules:               1
	-> Info violation RuleUID: asam.net:xodr:1.7.0:road.geometry.param_poly3.length_match
Warning violated rules:            0
Error violated rules:              0
```

**How was the PR tested?**
1. Unit-test with  sample data. All unit tests passed.

