### PR TITLE
Fix minor issues on report modules

### DIFF
--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
@@ -650,15 +650,6 @@ void cCheckerWidget::ShowIssue(cIssue *const itemToShow, const cLocationsContain
                 }
             }
         }
-        else
-        {
-            // This is the implementation of very simple reports. If a issue point to a
-            // xodr or xosc file, it should have a FileLocation
-
-            // If issue referes to an OpenDRIVE, show it!
-            if (hasInputPath)
-                ShowInputIssue(itemToShow, -1);
-        }
     }
 }
 

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -260,7 +260,7 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
     std::list<cIssue *> issues;
     std::list<cRule *> rules;
     std::list<cMetadata *> metadata;
-    std::set<std::string> info_violated_rules;
+    std::set<std::string> info_rules;
     std::set<std::string> warning_violated_rules;
     std::set<std::string> error_violated_rules;
     std::set<std::string> addressed_rules;
@@ -358,7 +358,7 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
                             eIssueLevel current_issue_level = (*it_Issue)->GetIssueLevel();
                             if (current_issue_level == eIssueLevel::INFO_LVL)
                             {
-                                info_violated_rules.insert((*it_Issue)->GetRuleUID());
+                                info_rules.insert((*it_Issue)->GetRuleUID());
                             }
                             if (current_issue_level == eIssueLevel::WARNING_LVL)
                             {
@@ -420,7 +420,7 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
             ss << "\n" << BASIC_SEPARATOR_LINE << "\n";
         }
 
-        ss << "Addressed vs Violated rules report \n\n";
+        ss << "Rules report \n\n";
 
         ss << "\nTotal number of addressed rules:   " << addressed_rules.size();
         for (const auto &str : addressed_rules)
@@ -428,14 +428,14 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
             ss << "\n\t-> Addressed RuleUID: " << str << "\n";
         }
 
-        int total_number_of_violated_rules =
-            info_violated_rules.size() + warning_violated_rules.size() + error_violated_rules.size();
-        ss << "\nTotal number of violated rules:    " << total_number_of_violated_rules << "\n";
+        int total_number_of_rules_with_issues =
+            info_rules.size() + warning_violated_rules.size() + error_violated_rules.size();
+        ss << "\nTotal number of rules with found issues:    " << total_number_of_rules_with_issues << "\n";
 
-        ss << "\nInfo violated rules:               " << info_violated_rules.size();
-        for (const auto &str : info_violated_rules)
+        ss << "\nRules for info:                    " << info_rules.size();
+        for (const auto &str : info_rules)
         {
-            ss << "\n\t-> Info violation RuleUID: " << str;
+            ss << "\n\t-> Info RuleUID: " << str;
         }
         ss << "\nWarning violated rules:            " << warning_violated_rules.size();
         for (const auto &str : warning_violated_rules)

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -437,12 +437,12 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
         {
             ss << "\n\t-> RuleUID with info: " << str;
         }
-        ss << "\nRule with warning issues:            " << warning_violated_rules.size();
+        ss << "\nRules with warning issues:            " << warning_violated_rules.size();
         for (const auto &str : warning_violated_rules)
         {
             ss << "\n\t-> RuleUID with warning issue: " << str;
         }
-        ss << "\nRule with error issues:              " << error_violated_rules.size();
+        ss << "\nRules with error issues:              " << error_violated_rules.size();
         for (const auto &str : error_violated_rules)
         {
             ss << "\n\t-> RuleUID with error issue: " << str;

--- a/src/report_modules/report_module_text/src/report_format_text.cpp
+++ b/src/report_modules/report_module_text/src/report_format_text.cpp
@@ -432,20 +432,20 @@ void WriteResults(const char *file, cResultContainer *ptrResultContainer)
             info_rules.size() + warning_violated_rules.size() + error_violated_rules.size();
         ss << "\nTotal number of rules with found issues:    " << total_number_of_rules_with_issues << "\n";
 
-        ss << "\nRules for info:                    " << info_rules.size();
+        ss << "\nRules for information:               " << info_rules.size();
         for (const auto &str : info_rules)
         {
-            ss << "\n\t-> Info RuleUID: " << str;
+            ss << "\n\t-> RuleUID with info: " << str;
         }
-        ss << "\nWarning violated rules:            " << warning_violated_rules.size();
+        ss << "\nRule with warning issues:            " << warning_violated_rules.size();
         for (const auto &str : warning_violated_rules)
         {
-            ss << "\n\t-> Warning violation RuleUID: " << str;
+            ss << "\n\t-> RuleUID with warning issue: " << str;
         }
-        ss << "\nError violated rules:              " << error_violated_rules.size();
+        ss << "\nRule with error issues:              " << error_violated_rules.size();
         for (const auto &str : error_violated_rules)
         {
-            ss << "\n\t-> Error violation RuleUID: " << str;
+            ss << "\n\t-> RuleUID with error issue: " << str;
         }
 
         ss << "\n" << BASIC_SEPARATOR_LINE << "\n";


### PR DESCRIPTION
**Description**

Addressing #173 , remove the undesired behavior of the line highlighter to go to first row when clicking on issue text

Addressing #181, cleanup text report modules for clarity

**How was the PR tested?**
1. Unit-test with  sample data. All unit tests passed.

**Notes**

New updated text report output

```
Total number of rules with found issues:    3

Rules for information:               1
	-> RuleUID with info: asam.net:xodr:1.7.0:road.geometry.param_poly3.length_match
Rules with warning issues:            1
	-> RuleUID with warning issue: asam.net:xodr:1.7.0:performance.avoid_redundant_info
Rules with error issues:              1
	-> RuleUID with error issue: asam.net:otx:1.0.0:core.chk_005.no_use_of_undefined_import_prefixes
```
