### PR TITLE
Add popup and message when no issues found

### DIFF
--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
@@ -11,6 +11,7 @@
 #include <QtCore/QTextStream>
 #include <QtWidgets/QHeaderView>
 #include <QtWidgets/QLabel>
+#include <QtWidgets/QMessageBox>
 #include <QtWidgets/QSplitter>
 #include <QtWidgets/QTextEdit>
 #include <QtWidgets/QTreeWidget>
@@ -260,6 +261,25 @@ void cCheckerWidget::LoadIssues(std::list<cIssue *> issues) const
         cIssue *firstIssue = issues.front();
         SelectIssue(firstIssue);
         ShowIssue(firstIssue, nullptr);
+    }
+
+    if (issues.size() == 0)
+    {
+        QTreeWidgetItem *newItem = new QTreeWidgetItem(_issueBox);
+
+        newItem->setToolTip(0, "Identifier");
+        newItem->setText(0, QString("-"));
+        newItem->setText(1, QString("-"));
+        newItem->setText(2, QString("-"));
+        newItem->setText(3, QString("No Issues Found"));
+        _issueBox->setItemSelected(newItem, true);
+        _issueDetailsTextWidget->setText(QString("No issues found in selected xqar file"));
+        _issueBox->addTopLevelItem(newItem);
+        QMessageBox msgBox;
+        msgBox.setWindowTitle("Result file info");
+        msgBox.setStandardButtons(QMessageBox::Ok);
+        msgBox.setText("No issues found in selected xqar file");
+        msgBox.exec();
     }
 
     _issueBox->expandAll();


### PR DESCRIPTION
**Description**

Addressing #179 , Add popup and information strings when result file contains no issue

E.g.

![Screenshot from 2024-09-23 10-20-22](https://github.com/user-attachments/assets/91bdbd39-d538-4191-855e-3afb6a2f72c0)


**How was the PR tested?**
1. Unit-test with  sample data. All unit tests passed.
