### PR TITLE
Adds optional Json Format Report module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VSCode
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 
+option(ASAM_QC_JSON_REPORT_FORMAT_ENABLE 
+  "Compile Report Format JSON utility. Requires nlohmann-json as dependency" OFF)
+
 file(STRINGS version QC4OPENX_VERSION LIMIT_COUNT 1)
 project(qc4openx VERSION ${QC4OPENX_VERSION})
 

--- a/src/report_modules/CMakeLists.txt
+++ b/src/report_modules/CMakeLists.txt
@@ -8,3 +8,6 @@
 add_subdirectory(report_module_text)
 add_subdirectory(report_module_gui)
 add_subdirectory(report_module_github_ci)
+if(ASAM_QC_JSON_REPORT_FORMAT_ENABLE)
+  add_subdirectory(report_module_json)
+endif()

--- a/src/report_modules/report_module_json/CMakeLists.txt
+++ b/src/report_modules/report_module_json/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright 2024 ASAM eV
+#
+# This Source Code Form is subject to the terms of the Mozilla
+# Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+project(JsonReport)
+
+add_subdirectory(dependencies/nlohman-json)
+
+add_executable(${PROJECT_NAME}
+    src/report_format_json.h
+    src/report_format_json.cpp
+    src/report_format_json_utils.cpp
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE 
+  nlohmann_json::nlohmann_json
+  qc4openx-common 
+  $<$<PLATFORM_ID:Linux>:stdc++fs>)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER report_modules)

--- a/src/report_modules/report_module_json/README.md
+++ b/src/report_modules/report_module_json/README.md
@@ -1,0 +1,102 @@
+# Report Formatter to JSON
+
+This is an optional report formatter for Quality checker. It uses `nlohmann-json`
+to create a JSON report of the result file.
+
+## Build and Install
+
+This is an optional module to create a report in JSON format. CMake will
+automatically collect the dependency for this optional module via `FetchContent`. 
+In order to build this module, the following option should be added at CMake 
+configuration:
+
+```
+cmake [...] -DASAM_QC_JSON_REPORT_FORMAT_ENABLE=ON [...]
+```
+
+Build and install the overall project as defined in the [`INSTALL` guide](/INSTALL.md)
+
+## Configuration
+
+### Parameters
+
+The report module supports the following parameters:
+
+| Name | Type | Default Value | Description |
+|------|------|---------------|-------------|
+| `strInputFile` | String | `"Result.xqar"` | Defines the input result file name |
+| `strReportFile` | String | `"Report.json"` | Defines the output filename |
+| `intIndent` | Integer | `2` | Defines the indentation levels for the dumped JSON. Value strictly less than 0 creates a minified JSON |
+
+### Configuration
+
+The following snippet is an example configuration for the report module:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Config>
+    <!-- 
+      ... Omitted configuration for 
+             input files ...
+             and bundles ... 
+    -->
+
+    <ReportModule application="JsonReport">
+        <Param name="strInputFile" value="Result.xqar" />
+        <Param name="strReportFile" value="Report.json" />
+        <Param name="intIndent" value="2"/>
+    </ReportModule>
+</Config>
+```
+
+### Manifest
+
+This is an example of the manifest that can be used to load the module:
+
+```jsonc
+{
+  "modules": [
+    {
+      "name": "JsonReport",
+      "exec_type": "executable",
+      "module_type": "report_module",
+      "exec_command": "JsonReport $ASAM_QC_FRAMEWORK_CONFIG_FILE"
+    }
+  ]
+}
+```
+
+The `"exec_command"` should be customized accordingly to user setup.
+
+## Output Schema
+
+A schema of the output, with description of the fields is available in 
+[`schema/output-schema.json`](schema/output-schema.json).
+
+## Licenses for Dependencies
+
+### nlohmann-json
+
+Repository: [github.com/nlohmann/json](https://github.com/nlohmann/json)
+
+> MIT License 
+> 
+> Copyright (c) 2013-2022 Niels Lohmann
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.

--- a/src/report_modules/report_module_json/dependencies/nlohman-json/CMakeLists.txt
+++ b/src/report_modules/report_module_json/dependencies/nlohman-json/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright 2024 ASAM eV
+#
+# This Source Code Form is subject to the terms of the Mozilla
+# Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(JSON_BuildTests OFF CACHE INTERNAL "")
+set(JSON_Install OFF CACHE INTERNAL "")
+
+include(FetchContent)
+FetchContent_Declare(nlohmann_json
+    URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.zip
+    DOWNLOAD_EXTRACT_TIMESTAMP ON
+    EXCLUDE_FROM_ALL)
+
+project(nhlomann_json_dependency
+  VERSION 3.11.3)
+FetchContent_MakeAvailable(nlohmann_json)

--- a/src/report_modules/report_module_json/schema/output-schema.json
+++ b/src/report_modules/report_module_json/schema/output-schema.json
@@ -1,0 +1,309 @@
+{
+  "type": "object",
+  "properties": {
+    "inputFile": {
+      "type": "string",
+      "descrition": "Input file defined for the current run of the checker"
+    },
+    "bundles": {
+      "type": "object",
+      "description": "Container for the different bundles executed",
+      "patternProperties": {
+        "\\w+": {
+          "type": "object",
+          "description": "Bundle definition. Key is name of the bundle",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the bundle, same as key of the object"
+            },
+            "summary": {
+              "type": "string",
+              "description": "Human readable description of the bundle run"
+            },
+            "buildDate": {
+              "type": "string",
+              "description": "bundle build date in YYYY-MM-DD date format",
+              "format": "date"
+            },
+            "description": {
+              "type": "string",
+              "decription": "Bundle provided description"
+            },
+            "parameters": {
+              "type": "object",
+              "description": "Parameters defined on the bundle. Keys are parameters name",
+              "patternProperties": {
+                "\\w+": {
+                  "type": "string",
+                  "description": "Value for the parameters"
+                }
+              }
+            },
+            "checkers": {
+              "type": "object",
+              "description": "Collection of checkers declared by the bundle, properties names are name of checker",
+              "patternProperties": {
+                "\\w+": {
+                  "type": "object",
+                  "description": "Definition of the results for a single checker",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Identifier for the checker"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Description of the checker"
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "Checker report status"
+                    },
+                    "summary": {
+                      "type": "string",
+                      "description": "Checker summary report"
+                    },
+                    "parameters": {
+                      "type": "object",
+                      "description": "Parameters defined on the checker. Keys are parameters name",
+                      "patternProperties": {
+                        "\\w+": {
+                          "type": "string",
+                          "description": "Value for the parameters"
+                        }
+                      }
+                    },
+                    "issues": {
+                      "type": "array",
+                      "description": "List of issue declared by the checker",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "level": {
+                            "type": "string",
+                            "description": "Level for the issue",
+                            "enum": [
+                              "info",
+                              "warning",
+                              "description"
+                            ]
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "Description for the issue provided by the checker"
+                          },
+                          "ruleID": {
+                            "type": "string",
+                            "description": "Optional rule unique identifier related to issue"
+                          },
+                          "locations": {
+                            "type": "array",
+                            "description": "Locations informations related to the current issue",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "description": "File location object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "file"
+                                    },
+                                    "row": {
+                                      "type": "integer"
+                                    },
+                                    "column": {
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "row",
+                                    "column"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "description": "XML location object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "xml"
+                                    },
+                                    "xpath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "xpath"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "description": "Inertial location object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "const": "inertial"
+                                    },
+                                    "x": {
+                                      "type": "number"
+                                    },
+                                    "y": {
+                                      "type": "number"
+                                    },
+                                    "z": {
+                                      "type": "number"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "x",
+                                    "y",
+                                    "z"
+                                  ]
+                                }
+                              ]
+                            }
+                          },
+                          "domainSpecificInfo": {
+                            "type": "object",
+                            "description": "Container for optional domain specific information, in xml format.We try to escape it but we cannot guarantee it will work",
+                            "patternProperties": {
+                              "\\w+": {
+                                "type": "object",
+                                "description": "Domain specific information. Name is also pattern property key",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Name of the pattern property for the Domain Specific Info"
+                                  },
+                                  "xml": {
+                                    "type": "string",
+                                    "format": "xml",
+                                    "description": "Escaped XML document with the domain specific info"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "xml"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "required": [
+                          "level",
+                          "description"
+                        ]
+                      }
+                    },
+                    "rules": {
+                      "type": "array",
+                      "description": "List of rules addressed by the current checker",
+                      "items": {
+                        "type": "string",
+                        "description": "Rules Unique Identifier"
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "description": "Container for user specified metadata",
+                      "patternProperties": {
+                        "\\w+": {
+                          "type": "object",
+                          "description": "Metadata value and description object. Key is equal to pattern property",
+                          "properties": {
+                            "key": {
+                              "type": "string",
+                              "description": "Key for the current metadata"
+                            },
+                            "value": {
+                              "type": "string",
+                              "description": "Value for the current metadata"
+                            },
+                            "decription": {
+                              "type": "string",
+                              "description": "Description for the current metadata"
+                            },
+                            "required": [
+                              "key",
+                              "value",
+                              "description"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "required": [
+              "name",
+              "summary",
+              "buildDate",
+              "buildVarsion",
+              "description"
+            ]
+          }
+        }
+      },
+      "report": {
+        "type": "object",
+        "description": "Summary for addressed rules",
+        "properties": {
+          "addressed": {
+            "type": "array",
+            "description": "list of all addressed rules",
+            "items": {
+              "type": "string",
+              "description": "Rule UID value"
+            }
+          },
+          "violated": {
+            "type": "object",
+            "description": "Summary for violated rules, per severity",
+            "properties": {
+              "info": {
+                "type": "array",
+                "description": "list of all addressed rules with info issues",
+                "items": {
+                  "type": "string",
+                  "description": "Rule UID value"
+                }
+              },
+              "warning": {
+                "type": "array",
+                "description": "list of all addressed rules with warning issues",
+                "items": {
+                  "type": "string",
+                  "description": "Rule UID value"
+                }
+              },
+              "error": {
+                "type": "array",
+                "description": "list of all addressed rules with error issues",
+                "items": {
+                  "type": "string",
+                  "description": "Rule UID value"
+                }
+              }
+            },
+            "required": [
+              "error",
+              "warning",
+              "info"
+            ]
+          }
+        },
+        "required": [
+          "addressed",
+          "violated"
+        ]
+      }
+    }
+  }
+}

--- a/src/report_modules/report_module_json/src/report_format_json.cpp
+++ b/src/report_modules/report_module_json/src/report_format_json.cpp
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2024 ASAM eV
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "report_format_json.h"
+#include "common/config_format/c_configuration.h"
+#include "common/config_format/c_configuration_report_module.h"
+#include "common/result_format/c_checker.h"
+#include "common/result_format/c_checker_bundle.h"
+#include "common/result_format/c_domain_specific_info.h"
+#include "common/result_format/c_file_location.h"
+#include "common/result_format/c_inertial_location.h"
+#include "common/result_format/c_issue.h"
+#include "common/result_format/c_locations_container.h"
+#include "common/result_format/c_metadata.h"
+#include "common/result_format/c_parameter_container.h"
+#include "common/result_format/c_result_container.h"
+#include "common/result_format/c_xml_location.h"
+
+#include "common/qc4openx_filesystem.h"
+#include <memory>
+#include <set>
+
+#include "nlohmann/json.hpp"
+
+const std::map<eIssueLevel, std::string> mapIssueLevelToString = {
+    {eIssueLevel::INFO_LVL, "info"}, {eIssueLevel::WARNING_LVL, "warning"}, {eIssueLevel::ERROR_LVL, "error"}};
+
+std::string WriteResults(std::unique_ptr<cResultContainer> &ptrResultContainer, int indent);
+
+int RunJsonReport(const cParameterContainer &inputParams);
+
+void PrintDOMElement(DOMElement *element, std::stringstream &ss, int indent = 0, int startIndent = 0);
+
+std::string ReplaceString(const std::string &input, const std::string &search, const std::string replace);
+
+// Main Programm
+int main(int argc, char *argv[])
+{
+    std::string strToolpath = argv[0];
+
+    if (argc != 2)
+    {
+        ShowHelp(strToolpath);
+
+        if (argc < 2)
+            return 0;
+        else
+            return -1;
+    }
+
+    std::string strFilepath = argv[1];
+    struct stat fileStatus;
+
+    XMLPlatformUtils::Initialize();
+
+    cParameterContainer inputParams;
+
+    // Default parameters
+    inputParams.SetParam("strInputFile", defaultStrInputFile);
+    inputParams.SetParam("strReportFile", defaultStrReportFile);
+    inputParams.SetParam("intIndent", defaultIntIndent);
+
+    if (StringEndsWith(ToLower(strFilepath), ".xqar"))
+    {
+        if (!fs::exists(strFilepath.c_str()))
+        {
+            std::cerr << "Could not open file '" << strFilepath << "'!" << std::endl
+                      << "Abort generating report!" << std::endl;
+
+            XMLPlatformUtils::Terminate();
+            return 1;
+        }
+
+        inputParams.SetParam("strInputFile", strFilepath);
+    }
+    else if (StringEndsWith(ToLower(strFilepath), ".xml"))
+    {
+        cConfiguration configuration;
+
+        if (!cConfiguration::ParseFromXML(&configuration, strFilepath))
+        {
+            std::cerr << "Could not read configuration! Abort." << std::endl;
+
+            XMLPlatformUtils::Terminate();
+            return -1;
+        }
+
+        inputParams.Overwrite(configuration.GetParams());
+
+        cConfigurationReportModule *reportModuleConfig = configuration.GetReportModuleByName(moduleName);
+        if (nullptr != reportModuleConfig)
+            inputParams.Overwrite(reportModuleConfig->GetParams());
+        else
+            std::cerr << "No configuration for module '" << moduleName << "' found. Start with default params."
+                      << std::endl;
+        try
+        {
+            const std::string intIndent = inputParams.GetParam("intIndent");
+            const int indent = std::stoi(intIndent);
+        }
+        catch (...)
+        {
+            std::cerr << "Invalid parameter 'intIndent' for module '" << moduleName
+                      << "' found. Using default params value." << std::endl;
+            inputParams.SetParam("intIndent", defaultIntIndent);
+        }
+    }
+    else if (StringEndsWith(ToLower(strFilepath), "--defaultconfig"))
+    {
+        WriteDefaultConfig();
+        XMLPlatformUtils::Terminate();
+        return 0;
+    }
+    else if (strcmp(strFilepath.c_str(), "-h") == 0 || strcmp(strFilepath.c_str(), "--help") == 0)
+    {
+        ShowHelp(strToolpath);
+        XMLPlatformUtils::Terminate();
+        return 0;
+    }
+    else
+    {
+        ShowHelp(strToolpath);
+        XMLPlatformUtils::Terminate();
+        return -1;
+    }
+
+    const int result = RunJsonReport(inputParams);
+    XMLPlatformUtils::Terminate();
+    return result;
+}
+
+int RunJsonReport(const cParameterContainer &inputParams)
+{
+    std::unique_ptr<cResultContainer> pResultContainer(new cResultContainer());
+    int indent = defaultIntIndent;
+    try
+    {
+        indent = std::stoi(inputParams.GetParam("intIndent"));
+    }
+    catch (...)
+    {
+        indent = defaultIntIndent;
+    }
+
+    try
+    {
+        const std::string strReportFile = inputParams.GetParam("strReportFile");
+        pResultContainer->AddResultsFromXML(inputParams.GetParam("strInputFile"));
+        const std::string result = WriteResults(pResultContainer, indent);
+
+        {
+            std::ofstream reportFile;
+            reportFile.open(strReportFile);
+            reportFile << result;
+            reportFile.close();
+        }
+    }
+    catch (...)
+    {
+        std::cerr << "Unknown error while formatting results file" << std::endl;
+        return 2;
+    }
+
+    pResultContainer->Clear();
+    return 0;
+}
+
+void PrintDOMElement(DOMElement *element, std::stringstream &ss, int indent, int startIndent)
+{
+    if (!element)
+        return;
+
+    // Convert the tag name to a string
+    char *tagName = XMLString::transcode(element->getTagName());
+    for (int i = 0; i < indent + startIndent; ++i)
+        ss << "  ";
+    ss << "<" << tagName;
+
+    // attributes
+    DOMNamedNodeMap *attributes = element->getAttributes();
+    XMLSize_t numAttrs = attributes->getLength();
+    for (XMLSize_t i = 0; i < numAttrs; ++i)
+    {
+        DOMNode *attr = attributes->item(i);
+        char *attrName = XMLString::transcode(attr->getNodeName());
+        char *attrValue = XMLString::transcode(attr->getNodeValue());
+        ss << " " << attrName << "=\\\"" << attrValue << "\\\"";
+        XMLString::release(&attrName);
+        XMLString::release(&attrValue);
+    }
+
+    ss << ">";
+
+    // children elements
+    DOMNodeList *children = element->getChildNodes();
+    XMLSize_t numChildren = children->getLength();
+    bool hasElementChildren = false;
+
+    for (XMLSize_t i = 0; i < numChildren; ++i)
+    {
+        DOMNode *child = children->item(i);
+        if (child->getNodeType() == DOMNode::TEXT_NODE)
+        {
+            char *textContent = XMLString::transcode(child->getNodeValue());
+            ss << ReplaceString(textContent, "\"", "\\\"");
+            XMLString::release(&textContent);
+        }
+        else if (child->getNodeType() == DOMNode::ELEMENT_NODE)
+        {
+            hasElementChildren = true;
+            ss << std::endl;
+            PrintDOMElement(dynamic_cast<DOMElement *>(child), ss, indent + 1, startIndent);
+        }
+    }
+
+    if (hasElementChildren)
+    {
+        ss << std::endl;
+        for (int i = 0; i < indent + startIndent; ++i)
+            ss << "  ";
+    }
+
+    ss << "</" << tagName << ">";
+    XMLString::release(&tagName);
+}
+
+bool IsWhitespaceOrEmpty(const std::string &line)
+{
+    return std::all_of(line.begin(), line.end(), [](unsigned char c) { return std::isspace(c); });
+}
+
+void RemoveEmptyLines(std::stringstream &ss)
+{
+    std::string line;
+    std::stringstream tempStream;
+    while (std::getline(ss, line))
+    {
+        if (!IsWhitespaceOrEmpty(line))
+        {
+            tempStream << line << std::endl;
+        }
+    }
+    ss.str(tempStream.str());
+}
+
+std::string WriteResults(std::unique_ptr<cResultContainer> &ptrResultContainer, int indent)
+{
+    if (!ptrResultContainer->HasCheckerBundles())
+        return "{}";
+
+    nlohmann::json json;
+
+    std::list<cCheckerBundle *> bundles = ptrResultContainer->GetCheckerBundles();
+    std::list<cChecker *> checkers;
+    std::list<cIssue *> issues;
+    std::list<cRule *> rules;
+    std::list<cMetadata *> metadata;
+    std::set<std::string> info_violated_rules;
+    std::set<std::string> warning_violated_rules;
+    std::set<std::string> error_violated_rules;
+    std::set<std::string> addressed_rules;
+
+    if ((*bundles.begin())->GetInputFileName().size() > 0)
+        json["inputFile"] = (*bundles.begin())->GetInputFileName(false);
+
+    // Loop over all checkers
+    for (const auto &bundle : bundles)
+    {
+        nlohmann::json json_bundle({
+            {"name", bundle->GetBundleName()},
+            {"buildData", bundle->GetBuildDate()},
+            {"buildVersion", bundle->GetBuildVersion()},
+            {"description", bundle->GetDescription()},
+            {"summary", bundle->GetSummary()},
+        });
+        json["bundles"][bundle->GetBundleName()] = json_bundle;
+        if (bundle->HasParams())
+        {
+            auto json_bundle_params = json_bundle["parameters"];
+            for (const auto param : bundle->GetParams())
+                json_bundle_params[param] = bundle->GetParam(param);
+        }
+
+        for (const auto checker : bundle->GetCheckers())
+        {
+            nlohmann::json json_checker({{"name", checker->GetCheckerID()},
+                                         {"description", checker->GetDescription()},
+                                         {"status", checker->GetStatus()},
+                                         {"summary", checker->GetSummary()}});
+            json_bundle["checkers"][checker->GetCheckerID()] = json_checker;
+            if (checker->HasParams())
+            {
+                auto json_checker_params = json_checker["parameters"];
+                for (const auto param : checker->GetParams())
+                    json_checker_params[param] = checker->GetParam(param);
+            }
+
+            for (const auto issue : checker->GetIssues())
+            {
+                nlohmann::json json_issue({{"level", mapIssueLevelToString.at(issue->GetIssueLevel())},
+                                           {"description", issue->GetDescription()}});
+
+                if (issue->GetRuleUID() != "")
+                {
+                    json_issue["ruleUID"] = issue->GetRuleUID();
+                    eIssueLevel current_issue_level = issue->GetIssueLevel();
+                    if (current_issue_level == eIssueLevel::INFO_LVL)
+                    {
+                        info_violated_rules.insert(issue->GetRuleUID());
+                    }
+                    if (current_issue_level == eIssueLevel::WARNING_LVL)
+                    {
+                        warning_violated_rules.insert(issue->GetRuleUID());
+                    }
+                    if (current_issue_level == eIssueLevel::ERROR_LVL)
+                    {
+                        error_violated_rules.insert(issue->GetRuleUID());
+                    }
+                }
+
+                for (const auto location : issue->GetLocationsContainer())
+                {
+                    nlohmann::json json_location;
+                    if (location->GetDescription() != "")
+                    {
+                        json_location["description"] = location->GetDescription();
+                    }
+                    for (const auto extended_info : location->GetExtendedInformations())
+                    {
+                        if (extended_info->IsType<cFileLocation *>())
+                        {
+                            const auto *loc = (const cFileLocation *)(extended_info);
+                            json_location["locations"].push_back(
+                                {{"type", "file"}, {"row", loc->GetRow()}, {"column", loc->GetColumn()}});
+                        }
+                        else if (extended_info->IsType<cXMLLocation *>())
+                        {
+                            const auto *loc = (const cXMLLocation *)(extended_info);
+                            json_location["locations"].push_back({{"type", "xml"}, {"xpath", loc->GetXPath()}});
+                        }
+                        else if (extended_info->IsType<cInertialLocation *>())
+                        {
+                            const auto *loc = (const cInertialLocation *)(extended_info);
+                            json_location["locations"].push_back(
+                                {{"type", "inertial"}, {"x", loc->GetX()}, {"y", loc->GetY()}, {"z", loc->GetZ()}});
+                        }
+                    }
+                    json_issue["locations"].push_back(json_location);
+                }
+
+                for (const auto domSpecInfo : issue->GetDomainSpecificInfo())
+                {
+                    std::stringstream dom_ss;
+                    PrintDOMElement(domSpecInfo->GetRoot(), dom_ss, 0, 0);
+                    RemoveEmptyLines(dom_ss);
+
+                    json_issue["domainSpecificInfo"][domSpecInfo->GetName()] =
+                        nlohmann::json({{"name", domSpecInfo->GetName()}, {"xml", dom_ss.str()}});
+                }
+
+                json_checker["issues"].push_back(json_issue);
+            }
+
+            for (const auto rule : checker->GetRules())
+            {
+                json_checker["rules"].push_back(rule->GetRuleUID());
+                addressed_rules.insert(rule->GetRuleUID());
+            }
+
+            for (const auto metadata : checker->GetMetadata())
+            {
+                json_checker["metadata"][metadata->GetKey()] = nlohmann::json({
+                    {"key", metadata->GetKey()},
+                    {"value", metadata->GetValue()},
+                    {"description", metadata->GetDescription()},
+                });
+            }
+        }
+    }
+
+    json["report"]["addressed"] = addressed_rules;
+    json["report"]["violated"]["info"] = info_violated_rules;
+    json["report"]["violated"]["warning"] = warning_violated_rules;
+    json["report"]["violated"]["error"] = error_violated_rules;
+
+    return json.dump(indent);
+}
+
+std::string ReplaceString(const std::string &input, const std::string &search, const std::string replace)
+{
+    std::string result = input;
+    while (true)
+    {
+        const auto position = result.find(search);
+        if (position == std::string::npos)
+            break;
+        result.replace(position, search.length(), replace);
+    }
+    return result;
+}

--- a/src/report_modules/report_module_json/src/report_format_json.h
+++ b/src/report_modules/report_module_json/src/report_format_json.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 ASAM eV
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include <string>
+
+#ifndef ASAM_QC_JSON_REPORT_FORMAT_MODULE_NAME
+#define ASAM_QC_JSON_REPORT_FORMAT_MODULE_NAME "JsonReport"
+#endif
+#ifndef ASAM_QC_JSON_REPORT_FORMAT_STRINPUTFILE
+#define ASAM_QC_JSON_REPORT_FORMAT_STRINPUTFILE "Result.xqar"
+#endif
+#ifndef ASAM_QC_JSON_REPORT_FORMAT_STRREPORTFILE
+#define ASAM_QC_JSON_REPORT_FORMAT_STRREPORTFILE "Report.json"
+#endif
+#ifndef ASAM_QC_JSON_REPORT_FORMAT_INTINDENT
+#define ASAM_QC_JSON_REPORT_FORMAT_INTINDENT 2
+#endif
+
+const std::string moduleName = ASAM_QC_JSON_REPORT_FORMAT_MODULE_NAME;
+const std::string defaultStrInputFile = ASAM_QC_JSON_REPORT_FORMAT_STRINPUTFILE;
+const std::string defaultStrReportFile = ASAM_QC_JSON_REPORT_FORMAT_STRREPORTFILE;
+const int defaultIntIndent = ASAM_QC_JSON_REPORT_FORMAT_INTINDENT;
+
+/**
+ * Main function for application
+ *
+ * @param    [in] argc                Number of arguments in shell
+ * @param    [in] argv                Pointer to arguments
+ *
+ * @return   The standard return value
+ */
+int main(int argc, char *argv[]);
+
+/**
+ * Shows the help for the application
+ * @param    [in] applicationName    The name of the application
+ */
+void ShowHelp(const std::string &applicationName);
+
+/**
+ * Writes the default configuration for a report
+ */
+void WriteDefaultConfig();

--- a/src/report_modules/report_module_json/src/report_format_json_utils.cpp
+++ b/src/report_modules/report_module_json/src/report_format_json_utils.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 ASAM eV
+ *
+ * This Source Code Form is subject to the terms of the Mozilla
+ * Public License, v. 2.0. If a copy of the MPL was not distributed
+ * with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "common/config_format/c_configuration.h"
+#include "common/config_format/c_configuration_report_module.h"
+#include "common/util.h"
+#include "report_format_json.h"
+
+#include <iostream>
+#include <string>
+
+void ShowHelp(const std::string &toolPath)
+{
+    std::string applicationName = toolPath;
+    std::string applicationNameWithoutExt = toolPath;
+    GetFileName(&applicationName, false);
+    GetFileName(&applicationNameWithoutExt, true);
+
+    std::cout << "\n\nUsage of " << applicationNameWithoutExt << ":" << std::endl;
+    std::cout << "\nRun the application with xqar file: \n" << applicationName << " result.xqar" << std::endl;
+    std::cout << "\nRun the application with dbqa configuration: \n" << applicationName << " config.xml" << std::endl;
+    std::cout << "\nRun the application with and write default configuration: \n"
+              << applicationName << " --defaultconfig" << std::endl;
+    std::cout << "\n\n";
+}
+
+void WriteDefaultConfig()
+{
+    cConfiguration defaultConfig;
+
+    {
+        // Do not refer to reportModuleConfig outside from this
+        cConfigurationReportModule *reportModuleConfig = defaultConfig.AddReportModule(moduleName);
+        reportModuleConfig->SetParam("strInputFile", defaultStrInputFile);
+        reportModuleConfig->SetParam("strReportFile", defaultStrReportFile);
+        reportModuleConfig->SetParam("intIndent", std::to_string(defaultIntIndent));
+    }
+
+    std::stringstream ssConfigFile;
+    ssConfigFile << moduleName << ".xml";
+    defaultConfig.WriteConfigurationToFile(ssConfigFile.str());
+}


### PR DESCRIPTION
**Description**

This commit introduces a new optional (and disabled by default) report format module for JSON file. Really similar to the Text Report module, uses nlohmann-json as dependency which is obtained automatically by CMake via `FetchContent`.

To enable compilation of the module a specific option (`ASAM_QC_JSON_REPORT_FORMAT_ENABLE`) should be enabled in CMake at configuration time.

Side note, adding `.vscode` as ignored directory for the project.

**Main changes**

 1. Adding a new report module subdirectory for report_module_json, with its own CMakeLists and dependency handling.
 2. Added the subdirectory in report_modules CMakeLists, conditional to a specific cmake configuration option
 3. Configuration option added with documentation in root CMakeLists file. Default value keeps the project as is.

**How was the PR tested?**

* [ ] Unit-test with some sample data. All unit tests passed.
* [x] Print output values. The printed outputs look reasonable.
* [x] Executed container locally and it worked. 

**Notes**

Adding `.vscode` as ignored directory (`.gitignore`)