### PR TITLE
Install ASAM Checker Bundles from PyPi instead of git repos

### DIFF
--- a/.github/workflows/build-on-change-linux-bare.yaml
+++ b/.github/workflows/build-on-change-linux-bare.yaml
@@ -138,21 +138,21 @@ jobs:
           pip install -e ${{ github.workspace }}/qc_framework
 
           mkdir "/home/$(whoami)/odr_out"
-          pip install asam-qc-opendrive@git+https://github.com/asam-ev/qc-opendrive@main
+          pip install asam-qc-opendrive
           qc_runtime --config="${{ github.workspace }}/.github/workflows/linux-files/odr_config.xml" --manifest="${{ github.workspace }}/.github/workflows/linux-manifest/framework.json" --working_dir="/home/$(whoami)/odr_out"
           if [ ! -f "/home/$(whoami)/odr_out/xodr_bundle_report.xqar" ]; then echo "Error: Odr output does not exist."; exit 1; fi
           if [ ! -f "/home/$(whoami)/odr_out/Result.xqar" ]; then echo "Error: Odr output does not exist."; exit 1; fi
           if [ ! -f "/home/$(whoami)/odr_out/Report.txt" ]; then echo "Error: Odr output does not exist."; exit 1; fi
 
           mkdir "/home/$(whoami)/osc_out"
-          pip install asam-qc-openscenarioxml@git+https://github.com/asam-ev/qc-openscenarioxml@main
+          pip install asam-qc-openscenarioxml
           qc_runtime --config="/home/$(whoami)/work/qc-framework/qc-framework/.github/workflows/linux-files/osc_config.xml" --manifest="/home/$(whoami)/work/qc-framework/qc-framework/.github/workflows/linux-manifest/framework.json" --working_dir="/home/$(whoami)/osc_out"
           if [ ! -f "/home/$(whoami)/osc_out/xosc_bundle_report.xqar" ]; then echo "Error: Osc output does not exist."; exit 1; fi
           if [ ! -f "/home/$(whoami)/osc_out/Result.xqar" ]; then echo "Error: Osc output does not exist."; exit 1; fi
           if [ ! -f "/home/$(whoami)/osc_out/Report.txt" ]; then echo "Error: Osc output does not exist."; exit 1; fi
 
           mkdir "/home/$(whoami)/otx_out"
-          pip install asam-qc-otx@git+https://github.com/asam-ev/qc-otx@main
+          pip install asam-qc-otx
           qc_runtime --config="/home/$(whoami)/work/qc-framework/qc-framework/.github/workflows/linux-files/otx_config.xml" --manifest="/home/$(whoami)/work/qc-framework/qc-framework/.github/workflows/linux-manifest/framework.json" --working_dir="/home/$(whoami)/otx_out"
           if [ ! -f "/home/$(whoami)/otx_out/otx_bundle_report.xqar" ]; then echo "Error: Otx output does not exist."; exit 1; fi
           if [ ! -f "/home/$(whoami)/otx_out/Result.xqar" ]; then echo "Error: Otx output does not exist."; exit 1; fi

--- a/.github/workflows/build-on-change-windows.yaml
+++ b/.github/workflows/build-on-change-windows.yaml
@@ -175,21 +175,21 @@ jobs:
           pip install -e $env:WORKING_PATH\qc-framework\qc-framework\qc_framework
 
           mkdir "$env:WORKING_PATH\odr_out"
-          pip install asam-qc-opendrive@git+https://github.com/asam-ev/qc-opendrive@main
+          pip install asam-qc-opendrive
           qc_runtime --config="$env:WORKING_PATH\qc-framework\qc-framework\.github\workflows\windows-files\odr_config.xml" --manifest="$env:WORKING_PATH\qc-framework\qc-framework\.github\workflows\windows-manifest\framework.json" --working_dir="$env:WORKING_PATH\odr_out"
           if (-not (Test-Path "$env:WORKING_PATH\odr_out\xodr_bundle_report.xqar")) { Throw "Error: Odr output does not exist." }
           if (-not (Test-Path "$env:WORKING_PATH\odr_out\Result.xqar")) { Throw "Error: Odr output does not exist." }
           if (-not (Test-Path "$env:WORKING_PATH\odr_out\Report.txt")) { Throw "Error: Odr output does not exist." }
 
           mkdir "$env:WORKING_PATH\osc_out"
-          pip install asam-qc-openscenarioxml@git+https://github.com/asam-ev/qc-openscenarioxml@main
+          pip install asam-qc-openscenarioxml
           qc_runtime --config="$env:WORKING_PATH\qc-framework\qc-framework\.github\workflows\windows-files\osc_config.xml" --manifest="$env:WORKING_PATH\qc-framework\qc-framework\.github\workflows\windows-manifest\framework.json" --working_dir="$env:WORKING_PATH\osc_out"
           if (-not (Test-Path "$env:WORKING_PATH\osc_out\xosc_bundle_report.xqar")) { Throw "Error: Osc output does not exist." }
           if (-not (Test-Path "$env:WORKING_PATH\osc_out\Result.xqar")) { Throw "Error: Osc output does not exist." }
           if (-not (Test-Path "$env:WORKING_PATH\osc_out\Report.txt")) { Throw "Error: Odr output does not exist." }
 
           mkdir "$env:WORKING_PATH\otx_out"
-          pip install asam-qc-otx@git+https://github.com/asam-ev/qc-otx@main
+          pip install asam-qc-otx
           qc_runtime --config="$env:WORKING_PATH\qc-framework\qc-framework\.github\workflows\windows-files\otx_config.xml" --manifest="$env:WORKING_PATH\qc-framework\qc-framework\.github\workflows\windows-manifest\framework.json" --working_dir="$env:WORKING_PATH\otx_out"
           if (-not (Test-Path "$env:WORKING_PATH\otx_out\otx_bundle_report.xqar")) { Throw "Error: Otx output does not exist." }
           if (-not (Test-Path "$env:WORKING_PATH\otx_out\Result.xqar")) { Throw "Error: Otx output does not exist." }

--- a/docker/Dockerfile.linux
+++ b/docker/Dockerfile.linux
@@ -52,9 +52,9 @@ RUN echo "Building framework..." && \
 
 RUN python3 -m pip install --no-cache-dir -r /app/demo_pipeline/requirements.txt && \
     python3 -m pip install --no-cache-dir /app/framework/qc_framework && \
-    python3 -m pip install asam-qc-opendrive@git+https://github.com/asam-ev/qc-opendrive@main && \
-    python3 -m pip install asam-qc-openscenarioxml@git+https://github.com/asam-ev/qc-openscenarioxml@main && \
-    python3 -m pip install asam-qc-otx@git+https://github.com/asam-ev/qc-otx@main
+    python3 -m pip install asam-qc-opendrive && \
+    python3 -m pip install asam-qc-openscenarioxml && \
+    python3 -m pip install asam-qc-otx
 
 
 # Framework test stage


### PR DESCRIPTION
**Description**

As all the ASAM Checker Bundles are now available on PyPi, this PR installs the checker bundles from the official PyPi server, instead of installing them from the GitHub repositories.

After this PR is merged, the release candidate v1.0.0-rc.1 will be published.

**Main changes**
1. Update the installation of ASAM Checker Bundles in CI/CD and the demo pipeline.

**How was the PR tested?**
1. Test on CI/CD

**Notes**
