### PR TITLE
Fix wrong link and update virtualenv apt package in documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -51,7 +51,7 @@ apt update && apt install -y \
     libqt5xmlpatterns5-dev \
     libxerces-c-dev \
     pkg-config \
-    python3.10-venv \
+    python3-venv \
     git
 ```
 

--- a/doc/manual/manifest_file.md
+++ b/doc/manual/manifest_file.md
@@ -11,7 +11,7 @@ There are two types of manifest files in the framework: **Framework manifest fil
 ## Framework Manifest File
 
 A framework manifest file is a JSON file containing a list of module manifest file paths.
-The [framework executable](python_framework_module.md) uses manifest files to discover
+The [framework executable](python_qc_framework.md) uses manifest files to discover
 and execute Checker Bundles, Result Poolers and Report Modules.
 
 The framework manifest file must follow the JSON format as in the example below.


### PR DESCRIPTION
**Description**

This PR contains two minor fixes for the documentation.

**Main changes**
1. Update the `virtualenv` apt package in Ubuntu to `python3-venv` (available on both 22.04 and 24.04) instead of `python3.10-venv` (only available on 22.04).
2. Fix a wrong link in the documentation.

**How was the PR tested?**
1. Test via CI/CD
2. Test by installing `python3-venv` inside Ubuntu 22.04 and 24.04 docker containers.

**Notes**

Fix the following issues:
* https://github.com/asam-ev/qc-framework/issues/211
* https://github.com/asam-ev/qc-framework/issues/212