### PR TITLE
Add preliminary support for vcpkg dependency management

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,12 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "vcpkg",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    }
+  ]
+}

--- a/scripts/cmake/qt_macros.cmake
+++ b/scripts/cmake/qt_macros.cmake
@@ -41,9 +41,9 @@ macro(qc4openx_install_qt DEST EXE)
 
     if (WIN32)
         # find windeployqt
-        find_program(QT_WINDEPLOYQT_EXECUTABLE windeployqt PATHS ${Qt5_PATH}/bin NO_DEFAULT_PATH)
+        find_program(QT_WINDEPLOYQT_EXECUTABLE windeployqt PATHS ${Qt5_PATH}/bin ${Qt5_PATH}/tools/qt5/bin NO_DEFAULT_PATH)
         if (NOT QT_WINDEPLOYQT_EXECUTABLE)
-            message(FATAL_ERROR "Could not find windeployqt in the Qt bin directory: ${Qt5_PATH}/bin!")
+            message(FATAL_ERROR "Could not find windeployqt in the Qt bin directory: ${Qt5_PATH}/bin or ${Qt5_PATH}/tools/qt5/bin !")
         endif()
 
         # escape slashes since we'll be using it inside code

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "bffcbb75f71553824aa948a7e7b4f798662a6fa7",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": [
+    "gtest",
+    "qt5",
+    "qt5-xmlpatterns",
+    "xerces-c"
+  ]
+}


### PR DESCRIPTION
This PR adds support for dependency management/build support via vcpkg, without changing the existing other build infrastructure. Defining a user-defined preset locally that inherits the vcpkg preset with added VCPKG_PATH pointing to your VCPKG install path (and potentially setting the INSTALL path to something useful) allows for use of this easily.

The idea is to use this as a stepping stone for

1. Simpler user-builds on Windows
2. Revamping the CI builds going forward to be less dependent on the VS and windows runner images changing

These will be addressed in future separate PRs.