### PR TITLE
Extended viewer interface

### DIFF
--- a/doc/manual/viewer_interface.md
+++ b/doc/manual/viewer_interface.md
@@ -27,6 +27,7 @@ ReportGUI:
 bool StartViewer();
 bool Initialize(const char* inputPath);
 bool AddIssue(void * issueToAdd);
+bool CanShowIssue(void * itemToShow, void* locationToShow);
 bool ShowIssue(void * itemToShow, void* locationToShow);
 const char* GetName();
 bool CloseViewer();
@@ -51,8 +52,13 @@ If you start a viewer the following functions are called in this order:
 If an error occurs during the startup process, the ReportGUI will call
 GetLastErrorMessage to print out the error in the ReportGUI itself.
 
-ShowIssue is triggered if you click on a InertialLocation issue in the ReportGUI.
-It will send the clicked issue and its location to the viewer.
+CanShowIssue is called to check whether an Issue is viewable in the viewer.
+If it returns true, then the viewer claims that it can show information for
+the given issue (and location).
+
+ShowIssue is triggered if you click on an issue in the ReportGUI for which
+CanShowIssue returned true. It will send the clicked issue and its location
+to the viewer.
 
 If the ReportGUI is closed a currently active Viewer receives the closeViewer
 call.

--- a/doc/manual/viewer_interface.md
+++ b/doc/manual/viewer_interface.md
@@ -11,14 +11,14 @@ with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ## Link with the Interface
 
 As described in the section "Using the ReportGUI" of [Using the Checker
-Framework](using_the_framework.md), it is possible to show issues in a 3D
-Viewer, if they have a valid position link. In general ASAM Quality Checker
-Framework doesn't provide a 3D Viewer but a C-interface to connect your own 3D
-Viewer to the ReportGUI. The ReportGUI loads viewer plugins in the form of
-shared libraries from the folder `bin/plugin`. A plugin needs to implement the
-interface `include/viewer/iConnector.h` and provide it via common C-API
-`__declspec(dllexport)` mechanism. The ReportGUI will load the library during
-startup and use your viewer to show issues graphically.
+Framework](using_the_framework.md), it is possible to show issues in external
+viewers, if they have valid location information. In general ASAM Quality Checker
+Framework doesn't provide its own 3D viewers but a C-interface to connect external
+3D and format-specific viewers to the ReportGUI. The ReportGUI loads viewer plugins
+in the form of shared libraries from the folder `bin/plugin`. A plugin needs to
+implement the interface `include/viewer/iConnector.h` and provide it via common
+C-API `__declspec(dllexport)` mechanism. The ReportGUI will load the library during
+startup and use the viewer plugin to show issues where applicable.
 
 The C-interface declares the following functions, which are called by the
 ReportGUI:
@@ -35,34 +35,37 @@ bool CloseViewer();
 const char* GetLastErrorMessage();
 ```
 
-This functions should be implemented inside your 3D viewer library to make your
-3D viewer compatible with the Report GUI. If the shared library is not loadable
+These functions should be implemented inside your viewer library to make your
+viewer compatible with the Report GUI. If the shared library is not loadable
 or one of the functions isn't defined, the ReportGUI will show an error and the
 viewer won't be available.
 
-It is not possible to implement and start multiple viewers. Starting a second
-viewer automatically closes the currently active one. A viewer is started via
-the context menu **File -> Start Viewer**.
+It is not possible to start multiple instances of one viewer plugin: Restarting
+a viewer automatically closes the currently active instance of that viewer. A
+viewer is started either via the context menu **File -> Start Viewer** (manually),
+or automatically on startup based on the input file and the viewers claim to
+support it, via `CanSupportFormat`. Note that multiple viewers of different
+plugins can be active at the same time.
 
-If you start a viewer the following functions are called in this order:
+If a viewer is started the following functions are called in this order:
 
-1. CanSupportFormat (further calls only if this function returns true)
-2. StartViewer
-3. Initialize
-4. AddIssue (will be called for each issue found)
+1. `CanSupportFormat` (further calls only if this function returns true)
+2. `StartViewer`
+3. `Initialize`
+4. `AddIssue` (will be called for each issue found)
 
 If an error occurs during the startup process, the ReportGUI will call
 GetLastErrorMessage to print out the error in the ReportGUI itself.
 
-CanShowIssue is called to check whether an Issue is viewable in the viewer.
+`CanShowIssue` is called to check whether an Issue is viewable in the viewer.
 If it returns true, then the viewer claims that it can show information for
 the given issue (and location).
 
-ShowIssue is triggered if you click on an issue in the ReportGUI for which
-CanShowIssue returned true. It will send the clicked issue and its location
+`ShowIssue` is triggered if you click on an issue in the ReportGUI for which
+`CanShowIssue` returned true. It will send the clicked issue and its location
 to the viewer.
 
-If the ReportGUI is closed a currently active Viewer receives the CloseViewer
+If the ReportGUI is closed all currently active viewers receive the `CloseViewer`
 call.
 
 ## Viewer Example
@@ -73,6 +76,6 @@ from the File menu. Click on issues that represent a 3D error and find the
 function calls inside the console window. Your own viewer interface
 implementation can use this information to show the error in 3D.
 
-A fully functioned viewer based on the [esmini simulator](https://esmini.github.io/) 
+A fully functional viewer based on the [esmini simulator](https://esmini.github.io/) 
 is also provided as part of the ASAM Quality Checker Framework. Please refer to 
 the [esmini viewer plugin](esmini_viewer_plugin.md) for details.

--- a/doc/manual/viewer_interface.md
+++ b/doc/manual/viewer_interface.md
@@ -24,6 +24,7 @@ The C-interface declares the following functions, which are called by the
 ReportGUI:
 
 ```c
+bool CanSupportFormat(const char* inputPath);
 bool StartViewer();
 bool Initialize(const char* inputPath);
 bool AddIssue(void * issueToAdd);
@@ -45,9 +46,10 @@ the context menu **File -> Start Viewer**.
 
 If you start a viewer the following functions are called in this order:
 
-1. StartViewer
-2. Initialize
-3. AddIssue (will be called for each issue found)
+1. CanSupportFormat (further calls only if this function returns true)
+2. StartViewer
+3. Initialize
+4. AddIssue (will be called for each issue found)
 
 If an error occurs during the startup process, the ReportGUI will call
 GetLastErrorMessage to print out the error in the ReportGUI itself.
@@ -60,7 +62,7 @@ ShowIssue is triggered if you click on an issue in the ReportGUI for which
 CanShowIssue returned true. It will send the clicked issue and its location
 to the viewer.
 
-If the ReportGUI is closed a currently active Viewer receives the closeViewer
+If the ReportGUI is closed a currently active Viewer receives the CloseViewer
 call.
 
 ## Viewer Example

--- a/examples/esmini_viewer/esmini_viewer.cpp
+++ b/examples/esmini_viewer/esmini_viewer.cpp
@@ -257,12 +257,7 @@ bool Initialize(const char *inputPath)
     bool isXoscFile = false;
     std::string odrFromXosc;
 
-    if (inputFileExtension == "otx")
-    {
-        lasterrormsg = "ERROR: Cannot load otx file in odr viewer";
-        return false;
-    }
-    else if (inputFileExtension == "xosc")
+    if (inputFileExtension == "xosc")
     {
         bool result = GetXodrFilePathFromXosc(inputPath, odrFromXosc);
         if (!result)
@@ -288,6 +283,11 @@ bool Initialize(const char *inputPath)
 
         // Call the function with arguments
         esmini_plugin.SE_Init(scenario_file_path.c_str(), 1, 1, 2, 0);
+    }
+    else
+    {
+        lasterrormsg = "ERROR: Cannot load unsupported file in odr viewer";
+        return false;
     }
 
     return true;

--- a/examples/esmini_viewer/esmini_viewer.cpp
+++ b/examples/esmini_viewer/esmini_viewer.cpp
@@ -298,6 +298,21 @@ bool AddIssue(void *issueToAdd)
     return true;
 }
 
+bool CanShowIssue(void *itemToShow, void *locationToShow)
+{
+    auto issue = static_cast<cIssue *>(itemToShow);
+    auto location = static_cast<cLocationsContainer *>(locationToShow);
+    std::list<cExtendedInformation *> extendedInfo = location->GetExtendedInformations();
+    for (cExtendedInformation *extInfo : extendedInfo)
+    {
+        // Show InertialLocations in Viewer
+        if (extInfo->IsType<cInertialLocation *>())
+            return true;
+    }
+
+    return false;
+}
+
 bool ShowIssue(void *itemToShow, void *locationToShow)
 {
     auto issue = static_cast<cIssue *>(itemToShow);

--- a/examples/esmini_viewer/esmini_viewer.cpp
+++ b/examples/esmini_viewer/esmini_viewer.cpp
@@ -205,21 +205,6 @@ class PluginLoader
 // Load the plugin (shared library)
 PluginLoader esmini_plugin;
 
-bool StartViewer()
-{
-    std::string esminiLibPath;
-    bool esminiLibFound = searchEsminiLibrary(esminiLibPath);
-    if (!esminiLibFound)
-    {
-        lasterrormsg =
-            "ERROR: Esmini library not found neither in ESMINI_LIB_PATH env variable nor in installation folder. "
-            "Cannot start viewer";
-        return false;
-    }
-
-    return esmini_plugin.Load(esminiLibPath);
-}
-
 std::string getFileExtension(const std::string &filename)
 {
     // Find the last occurrence of the dot character in the filename
@@ -234,6 +219,42 @@ std::string getFileExtension(const std::string &filename)
     {
         return ""; // No valid extension found
     }
+}
+
+bool CanSupportFormat(const char *inputPath)
+{
+    if (std::strcmp(inputPath, "") == 0)
+    {
+        lasterrormsg = "ERROR: No valid xosc or xodr file found.";
+        return false;
+    }
+
+    std::string inputFileExtension = getFileExtension(inputPath);
+
+    if (inputFileExtension == "xosc" || inputFileExtension == "xodr")
+    {
+        return true;
+    }
+    else
+    {
+        lasterrormsg = "ERROR: Cannot load unsupported file in odr viewer";
+        return false;
+    }
+}
+
+bool StartViewer()
+{
+    std::string esminiLibPath;
+    bool esminiLibFound = searchEsminiLibrary(esminiLibPath);
+    if (!esminiLibFound)
+    {
+        lasterrormsg =
+            "ERROR: Esmini library not found neither in ESMINI_LIB_PATH env variable nor in installation folder. "
+            "Cannot start viewer";
+        return false;
+    }
+
+    return esmini_plugin.Load(esminiLibPath);
 }
 
 bool Initialize(const char *inputPath)

--- a/examples/viewer_example/viewer_example.cpp
+++ b/examples/viewer_example/viewer_example.cpp
@@ -40,7 +40,7 @@ bool Initialize(const char *inputPath)
         lasterrormsg = "ERROR: No valid input file found.";
         return false;
     }
-    std::cout << "INITILAIZE VIEWER WITH INPUT FILE: " << inputPath << std::endl;
+    std::cout << "INITIALIZE VIEWER WITH INPUT FILE: " << inputPath << std::endl;
     return true;
 }
 

--- a/examples/viewer_example/viewer_example.cpp
+++ b/examples/viewer_example/viewer_example.cpp
@@ -40,6 +40,14 @@ bool AddIssue(void *issueToAdd)
     return true;
 }
 
+bool CanShowIssue(void *itemToShow, void *locationToShow)
+{
+    if (locationToShow == nullptr)
+        return false;
+
+    return true;
+}
+
 bool ShowIssue(void *itemToShow, void *locationToShow)
 {
     auto issue = static_cast<cIssue *>(itemToShow);

--- a/examples/viewer_example/viewer_example.cpp
+++ b/examples/viewer_example/viewer_example.cpp
@@ -16,6 +16,17 @@
 
 const char *lasterrormsg = "";
 
+bool CanSupportFormat(const char *inputPath)
+{
+    if (std::strcmp(inputPath, "") == 0)
+    {
+        lasterrormsg = "ERROR: No valid input file found.";
+        return false;
+    }
+    std::cout << "CAN SUPPORT FORMAT WITH INPUT FILE: " << inputPath << std::endl;
+    return true;
+}
+
 bool StartViewer()
 {
     std::cout << "START VIEWER EXAMPLE" << std::endl;
@@ -29,7 +40,7 @@ bool Initialize(const char *inputPath)
         lasterrormsg = "ERROR: No valid input file found.";
         return false;
     }
-    std::cout << "INITILAIZE VIEWER WITH INPUPT FILE: " << inputPath << std::endl;
+    std::cout << "INITILAIZE VIEWER WITH INPUT FILE: " << inputPath << std::endl;
     return true;
 }
 

--- a/include/viewer/i_connector.h
+++ b/include/viewer/i_connector.h
@@ -25,13 +25,19 @@ extern "C"
 #endif
 
     /**
+     * Checks if the viewer can support the format of the given input file
+     * \param inputPath Path to the input file
+     **/
+    VIEWER bool CanSupportFormat(const char *inputPath);
+
+    /**
      * Is called if the viewer application should be startet from main menu
      **/
     VIEWER bool StartViewer();
 
     /**
-     * Does the initialization with xosc file of an viewer
-     * \param xoscPath Path to an xosc file
+     * Does the initialization with input file of an viewer
+     * \param inputPath Path to the input file
      **/
     VIEWER bool Initialize(const char *inputPath);
 

--- a/include/viewer/i_connector.h
+++ b/include/viewer/i_connector.h
@@ -42,6 +42,13 @@ extern "C"
     VIEWER bool AddIssue(void *issueToAdd);
 
     /**
+     * Is called to determine if an issues can be shown.
+     * \param itemToShow The item which should be shown. Pointer to a cIssue class.
+     * \param locationToShow The location where to show the issue. Pointer to a cLocationsContainer class
+     **/
+    VIEWER bool CanShowIssue(void *itemToShow, void *locationToShow);
+    
+    /**
      * Is called if an issues has to be showed.
      * \param itemToShow The item which should be showed. Pointer to a cIssue class.
      * \param locationToShow The location where to show the issue. Pointer to a cLocationsContainer class

--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
@@ -366,7 +366,7 @@ void cCheckerWidget::FillIssueTreeItem(QTreeWidgetItem *treeItem, cIssue *const 
 
         for (const auto subIssue : issue->GetLocationsContainer())
         {
-            if (subIssue->HasExtendedInformation<cInertialLocation *>())
+            if (CanShowIssueIn3DViewer(issue, subIssue))
             {
                 isVisibleInViewer = true;
             }
@@ -666,13 +666,11 @@ void cCheckerWidget::ShowIssue(cIssue *const itemToShow, const cLocationsContain
                     if (hasInputPath)
                         ShowInputIssue(itemToShow, row);
                 }
-
-                // Show InertialLocations in Viewer
-                if (extInfo->IsType<cInertialLocation *>())
-                {
-                    ShowIssueIn3DViewer(itemToShow, locationToShow);
-                }
             }
+
+            // Potentially show in external viewer
+            if (CanShowIssueIn3DViewer(itemToShow, locationToShow))
+                    ShowIssueIn3DViewer(itemToShow, locationToShow);
         }
     }
 }

--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
@@ -383,13 +383,13 @@ void cCheckerWidget::FillIssueTreeItem(QTreeWidgetItem *treeItem, cIssue *const 
             {
                 treeItem->setSizeHint(1, QSize(35, 30));
                 treeItem->setIcon(1, QIcon(":/icons/marked_visible.png"));
-                treeItem->setToolTip(1, "Issue is marked in XML view and visible in XODR viewer");
+                treeItem->setToolTip(1, "Issue is marked in file view and visible in external viewer(s)");
             }
             else
             {
                 treeItem->setSizeHint(1, QSize(35, 30));
                 treeItem->setIcon(1, QIcon(":/icons/marked.png"));
-                treeItem->setToolTip(1, "Issue is marked in XML view");
+                treeItem->setToolTip(1, "Issue is marked in file view");
             }
         }
         else
@@ -398,7 +398,7 @@ void cCheckerWidget::FillIssueTreeItem(QTreeWidgetItem *treeItem, cIssue *const 
             {
                 treeItem->setSizeHint(1, QSize(35, 30));
                 treeItem->setIcon(1, QIcon(":/icons/visible.png"));
-                treeItem->setToolTip(1, "Issue is visible in XODR viewer");
+                treeItem->setToolTip(1, "Issue is visible in external viewer(s)");
             }
         }
     }
@@ -406,7 +406,7 @@ void cCheckerWidget::FillIssueTreeItem(QTreeWidgetItem *treeItem, cIssue *const 
     {
         treeItem->setSizeHint(1, QSize(35, 30));
         treeItem->setIcon(1, QIcon(":/icons/issue.png"));
-        treeItem->setToolTip(1, "Issue is not marked in XML view and not visible in XODR viewer");
+        treeItem->setToolTip(1, "Issue is not marked in file view and not visible in external viewer(s)");
     }
 
     treeItem->setSizeHint(2, QSize(35, 30));

--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.cpp
@@ -659,18 +659,19 @@ void cCheckerWidget::ShowIssue(cIssue *const itemToShow, const cLocationsContain
                 if (extInfo->IsType<cFileLocation *>())
                 {
                     cFileLocation *fileLocation = ((cFileLocation *)extInfo);
-
-                    int row = fileLocation->GetRow();
-
-                    // If issue referes to a file, show it!
-                    if (hasInputPath)
-                        ShowInputIssue(itemToShow, row);
+                    // If issue refers to a file, show it!
+                    if (hasInputPath) {
+                        if (fileLocation->HasRowColumn())
+                            ShowInputIssue(itemToShow, fileLocation->GetRow());
+                        else if (fileLocation->HasOffset())
+                            ShowInputIssueOffset(itemToShow, fileLocation->GetOffset());
+                    }
                 }
             }
 
             // Potentially show in external viewer
             if (CanShowIssueIn3DViewer(itemToShow, locationToShow))
-                    ShowIssueIn3DViewer(itemToShow, locationToShow);
+                ShowIssueIn3DViewer(itemToShow, locationToShow);
         }
     }
 }

--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.h
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.h
@@ -130,6 +130,11 @@ class cCheckerWidget : public QWidget
     /*
      * Invoked if an issue should be showed in 3DViewer.
      */
+    bool CanShowIssueIn3DViewer(const cIssue *const issue, const cLocationsContainer *locationToShow) const;
+
+    /*
+     * Invoked if an issue should be showed in 3DViewer.
+     */
     void ShowIssueIn3DViewer(const cIssue *const issue, const cLocationsContainer *locationToShow) const;
 };
 

--- a/src/report_modules/report_module_gui/src/ui/c_checker_widget.h
+++ b/src/report_modules/report_module_gui/src/ui/c_checker_widget.h
@@ -128,6 +128,12 @@ class cCheckerWidget : public QWidget
     void ShowInputIssue(const cIssue *const issue, const int row) const;
 
     /*
+     * Invoked if an issue will be showed.
+     * \param offset: Offset which should be displayed. -1 for no specific offset.
+     */
+    void ShowInputIssueOffset(const cIssue *const issue, const int offset) const;
+
+    /*
      * Invoked if an issue should be showed in 3DViewer.
      */
     bool CanShowIssueIn3DViewer(const cIssue *const issue, const cLocationsContainer *locationToShow) const;

--- a/src/report_modules/report_module_gui/src/ui/c_line_highlighter.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_line_highlighter.cpp
@@ -12,12 +12,21 @@
 void LineHighlighter::setLineToHighlight(int line)
 {
     lineNumber = line;
+    position = -1;
+    rehighlight();
+}
+
+void LineHighlighter::setOffsetToHighlight(int offset)
+{
+    lineNumber = -1;
+    position = offset;
     rehighlight();
 }
 
 void LineHighlighter::highlightBlock(const QString &text)
 {
-    if (lineNumber != -1 && currentBlock().blockNumber() == lineNumber)
+    if ((lineNumber != -1 && currentBlock().blockNumber() == lineNumber) ||
+        (position != -1 && currentBlock().contains(position)))
     {
         QTextCharFormat fmt;
         fmt.setBackground(Qt::yellow);

--- a/src/report_modules/report_module_gui/src/ui/c_line_highlighter.h
+++ b/src/report_modules/report_module_gui/src/ui/c_line_highlighter.h
@@ -14,15 +14,17 @@
 class LineHighlighter : public QSyntaxHighlighter
 {
   public:
-    LineHighlighter(QTextDocument *document) : QSyntaxHighlighter(document), lineNumber(-1)
+    LineHighlighter(QTextDocument *document) : QSyntaxHighlighter(document), lineNumber(-1), position(-1)
     {
     }
 
     void setLineToHighlight(int line);
+    void setOffsetToHighlight(int offset);
 
   protected:
     void highlightBlock(const QString &text) override;
 
   private:
     int lineNumber;
+    int position;
 };

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -237,6 +237,22 @@ cReportModuleWindow::cReportModuleWindow(cResultContainer *resultContainer, cons
                 break;
             }
 
+            // resolve function address CanSupportFormat here
+#ifdef WIN32
+            viewerEntries[i]->CanSupportFormat_f = (CanSupportFormat_ptr)GetProcAddress(viewer_dll, "CanSupportFormat");
+#else
+            viewerEntries[i]->CanSupportFormat_f = (CanSupportFormat_ptr)dlsym(viewer_dll, "CanSupportFormat");
+#endif
+
+            if (!viewerEntries[i]->CanSupportFormat_f)
+            {
+                QString text =
+                    QString("Could not locate the function CanSupportFormat (%1). Abort.").arg(viewer_list.at(i).baseName());
+                msgBox.setText(text);
+                msgBox.exec();
+                break;
+            }
+
             // resolve function address StartViewer here
 #ifdef WIN32
             viewerEntries[i]->StartViewer_f = (StartViewer_ptr)GetProcAddress(viewer_dll, "StartViewer");
@@ -493,8 +509,8 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
     msgBox.setWindowTitle(this->_reportModuleName + " Error");
     msgBox.setStandardButtons(QMessageBox::Ok);
 
-    // Start viewer when we have an input file
-    if (_results != nullptr && _results->HasInputFileName())
+    // Start viewer when we have an input file and it is supported
+    if (_results != nullptr && _results->HasInputFileName() && viewer->CanSupportFormat_f(_results->GetInputFilePath().c_str()))
     {
         setCursor(Qt::WaitCursor);
         QApplication::processEvents();
@@ -512,7 +528,7 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
             return;
         }
 
-        // Initilialize with xosc and xodr file
+        // Initilialize with input file
         result = viewer->Initialize_f(_results->GetInputFilePath().c_str());
 
         if (!result)
@@ -550,7 +566,12 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
     }
     else
     {
-        msgBox.setText("Cannot start because input file in result. Abort.");
+        if (_results == nullptr)
+            msgBox.setText("Cannot start because no result loaded. Abort.");
+        else if (!_results->HasInputFileName())
+            msgBox.setText("Cannot start because no input file in result. Abort.");
+        else
+            msgBox.setText("Cannot start because input file format in result is not supported by viewer. Abort.");
         msgBox.exec();
     }
 }

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -537,9 +537,10 @@ void cReportModuleWindow::ShowIssueInViewer(const cIssue *const issue, const cLo
 
 void cReportModuleWindow::closeEvent(QCloseEvent *)
 {
-    for (uint32_t i = 0; i < viewerEntries.size(); i++)
+    if (_viewerActive != nullptr)
     {
-        viewerEntries[i]->CloseViewer_f();
+        _viewerActive->CloseViewer_f();
+        _viewerActive = nullptr;
     }
 }
 

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -506,6 +506,8 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
         {
             QString errormsg = QString("StartViewer failed, abort. Error msg: ") + viewer->GetLastErrorMessage_f();
             msgBox.setText(errormsg);
+            setCursor(Qt::ArrowCursor);
+            QApplication::processEvents();
             msgBox.exec();
             return;
         }
@@ -518,6 +520,8 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
             std::cout << "errormsg this side: " << viewer->GetLastErrorMessage_f() << std::endl;
             QString errormsg = QString("Initialize failed, abort. Error msg: ") + viewer->GetLastErrorMessage_f();
             msgBox.setText(errormsg);
+            setCursor(Qt::ArrowCursor);
+            QApplication::processEvents();
             msgBox.exec();
             return;
         }
@@ -532,6 +536,8 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
             {
                 QString errormsg = QString("Adding error failed, abort. Error msg: ") + viewer->GetLastErrorMessage_f();
                 msgBox.setText(errormsg);
+                setCursor(Qt::ArrowCursor);
+                QApplication::processEvents();
                 msgBox.exec();
                 return;
             }

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -404,7 +404,7 @@ cReportModuleWindow::cReportModuleWindow(cResultContainer *resultContainer, cons
 }
 
 // Loads the result container
-void cReportModuleWindow::LoadResultContainer(cResultContainer *const container) const
+void cReportModuleWindow::LoadResultContainer(cResultContainer *const container)
 {
     QMap<QString, QString> fileReplacementMap;
     std::list<cCheckerBundle *> bundles = container->GetCheckerBundles();
@@ -413,6 +413,12 @@ void cReportModuleWindow::LoadResultContainer(cResultContainer *const container)
          itBundle++)
     {
         ValidateInputFile(*itBundle, &fileReplacementMap, "InputFile", "Input file");
+    }
+
+    // Auto (re-)start viewers for which we have supporting input file
+    for (const auto &viewer : viewerEntries)
+    {
+        StartViewer(viewer.get(), true);
     }
 
     if (_checkerWidget != nullptr)
@@ -490,24 +496,19 @@ void cReportModuleWindow::SaveResultFile()
     msgBox.exec();
 }
 
-void cReportModuleWindow::StartViewer(Viewer *viewer)
+void cReportModuleWindow::StartViewer(Viewer *viewer, bool suppressMessages)
 {
-    if (_viewerActive != nullptr)
+    if (viewer->isActive)
     {
-        std::cout << "We have already an active viewer, closing it first... " << std::endl;
-        if (!_viewerActive->CloseViewer_f())
+        std::cout << "Viewer is already active, closing it first... " << std::endl;
+        if (!viewer->CloseViewer_f())
         {
-            std::string error(_viewerActive->GetLastErrorMessage_f());
-            std::cout << "Closing the viewer " << _viewerActive->GetName_f() << " failed, error: " << error
+            std::string error(viewer->GetLastErrorMessage_f());
+            std::cout << "Closing the viewer " << viewer->GetName_f() << " failed, error: " << error
                       << std::endl;
         }
-
-        _viewerActive = nullptr;
+        viewer->isActive = false;
     }
-
-    QMessageBox msgBox;
-    msgBox.setWindowTitle(this->_reportModuleName + " Error");
-    msgBox.setStandardButtons(QMessageBox::Ok);
 
     // Start viewer when we have an input file and it is supported
     if (_results != nullptr && _results->HasInputFileName() && viewer->CanSupportFormat_f(_results->GetInputFilePath().c_str()))
@@ -520,11 +521,18 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
 
         if (!result)
         {
-            QString errormsg = QString("StartViewer failed, abort. Error msg: ") + viewer->GetLastErrorMessage_f();
-            msgBox.setText(errormsg);
             setCursor(Qt::ArrowCursor);
             QApplication::processEvents();
-            msgBox.exec();
+            if (!suppressMessages)
+            {
+                QMessageBox msgBox;
+                msgBox.setWindowTitle(this->_reportModuleName + " Error");
+                msgBox.setStandardButtons(QMessageBox::Ok);
+
+                QString errormsg = QString("StartViewer failed, abort. Error msg: ") + viewer->GetLastErrorMessage_f();
+                msgBox.setText(errormsg);
+                msgBox.exec();
+            }
             return;
         }
 
@@ -533,12 +541,20 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
 
         if (!result)
         {
-            std::cout << "errormsg this side: " << viewer->GetLastErrorMessage_f() << std::endl;
-            QString errormsg = QString("Initialize failed, abort. Error msg: ") + viewer->GetLastErrorMessage_f();
-            msgBox.setText(errormsg);
             setCursor(Qt::ArrowCursor);
             QApplication::processEvents();
-            msgBox.exec();
+            if (!suppressMessages)
+            {
+                QMessageBox msgBox;
+                msgBox.setWindowTitle(this->_reportModuleName + " Error");
+                msgBox.setStandardButtons(QMessageBox::Ok);
+
+                std::cout << "errormsg this side: " << viewer->GetLastErrorMessage_f() << std::endl;
+                QString errormsg = QString("Initialize failed, abort. Error msg: ") + viewer->GetLastErrorMessage_f();
+                msgBox.setText(errormsg);
+                msgBox.exec();
+            }
+            viewer->CloseViewer_f();
             return;
         }
 
@@ -550,11 +566,19 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
 
             if (!result)
             {
-                QString errormsg = QString("Adding error failed, abort. Error msg: ") + viewer->GetLastErrorMessage_f();
-                msgBox.setText(errormsg);
                 setCursor(Qt::ArrowCursor);
                 QApplication::processEvents();
-                msgBox.exec();
+                if (!suppressMessages)
+                {
+                    QMessageBox msgBox;
+                    msgBox.setWindowTitle(this->_reportModuleName + " Error");
+                    msgBox.setStandardButtons(QMessageBox::Ok);
+
+                    QString errormsg = QString("Adding error failed, abort. Error msg: ") + viewer->GetLastErrorMessage_f();
+                    msgBox.setText(errormsg);
+                    msgBox.exec();
+                }
+                viewer->CloseViewer_f();
                 return;
             }
         }
@@ -562,10 +586,13 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
         setCursor(Qt::ArrowCursor);
         QApplication::processEvents();
 
-        _viewerActive = viewer;
+        viewer->isActive = true;
     }
-    else
+    else if (!suppressMessages)
     {
+        QMessageBox msgBox;
+        msgBox.setWindowTitle(this->_reportModuleName + " Error");
+        msgBox.setStandardButtons(QMessageBox::Ok);
         if (_results == nullptr)
             msgBox.setText("Cannot start because no result loaded. Abort.");
         else if (!_results->HasInputFileName())
@@ -578,34 +605,43 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
 
 bool cReportModuleWindow::CheckIssueShowableInViewer(const cIssue *const issue, const cLocationsContainer *locationToShow)
 {
-    return (_viewerActive != nullptr) && _viewerActive->CanShowIssue_f(issue, locationToShow);
+    for (const auto &viewer : viewerEntries)
+    {
+        if (viewer->isActive && viewer->CanShowIssue_f(issue, locationToShow))
+            return true;
+    }
+    return false;
 }
 
 void cReportModuleWindow::ShowIssueInViewer(const cIssue *const issue, const cLocationsContainer *locationToShow)
 {
-    QMessageBox msgBox;
-    msgBox.setWindowTitle(this->_reportModuleName + " Error");
-    msgBox.setStandardButtons(QMessageBox::Ok);
-
-    if (_viewerActive != nullptr)
+    for (const auto &viewer : viewerEntries)
     {
-        bool result = _viewerActive->ShowIssue_f(issue, locationToShow);
-        if (!result)
+        if (viewer->isActive && viewer->CanShowIssue_f(issue, locationToShow))
         {
-            QString errormsg =
-                QString("Show issue failed, abort. Error msg: ") + _viewerActive->GetLastErrorMessage_f();
-            msgBox.setText(errormsg);
-            msgBox.exec();
+            bool result = viewer->ShowIssue_f(issue, locationToShow);
+            if (!result)
+            {
+                QMessageBox msgBox;
+                msgBox.setWindowTitle(this->_reportModuleName + " Error");
+                msgBox.setStandardButtons(QMessageBox::Ok);
+                QString errormsg =
+                    QString("Show issue failed, abort. Error msg: ") + viewer->GetLastErrorMessage_f();
+                msgBox.setText(errormsg);
+                msgBox.exec();
+            }
         }
     }
 }
 
 void cReportModuleWindow::closeEvent(QCloseEvent *)
 {
-    if (_viewerActive != nullptr)
+    for (const auto &viewer : viewerEntries)
     {
-        _viewerActive->CloseViewer_f();
-        _viewerActive = nullptr;
+        if (viewer->isActive)
+        {
+            viewer->CloseViewer_f();
+        }
     }
 }
 

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -165,6 +165,7 @@ cReportModuleWindow::cReportModuleWindow(cResultContainer *resultContainer, cons
 
     connect(_checkerWidget, &cCheckerWidget::Load, this, &cReportModuleWindow::loadFileContent);
     connect(_checkerWidget, &cCheckerWidget::ShowInputIssue, this, &cReportModuleWindow::highlightRow);
+    connect(_checkerWidget, &cCheckerWidget::CanShowIssueIn3DViewer, this, &cReportModuleWindow::CheckIssueShowableInViewer);
     connect(_checkerWidget, &cCheckerWidget::ShowIssueIn3DViewer, this, &cReportModuleWindow::ShowIssueInViewer);
 
     // Create Menu entries for all viewers in plugin
@@ -263,6 +264,22 @@ cReportModuleWindow::cReportModuleWindow(cResultContainer *resultContainer, cons
             {
                 QString text =
                     QString("Could not locate the function AddIssue (%1). Abort.").arg(viewer_list.at(i).baseName());
+                msgBox.setText(text);
+                msgBox.exec();
+                break;
+            }
+
+            // resolve function address CanShowIssue here
+#ifdef WIN32
+            viewerEntries[i]->CanShowIssue_f = (ShowIssue_ptr)GetProcAddress(viewer_dll, "CanShowIssue");
+#else
+            viewerEntries[i]->CanShowIssue_f = (ShowIssue_ptr)dlsym(viewer_dll, "CanShowIssue");
+#endif
+
+            if (!viewerEntries[i]->CanShowIssue_f)
+            {
+                QString text =
+                    QString("Could not locate the function CanShowIssue (%1). Abort.").arg(viewer_list.at(i).baseName());
                 msgBox.setText(text);
                 msgBox.exec();
                 break;
@@ -514,6 +531,11 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
         msgBox.setText("Cannot start because no XODR in result. Abort.");
         msgBox.exec();
     }
+}
+
+bool cReportModuleWindow::CheckIssueShowableInViewer(const cIssue *const issue, const cLocationsContainer *locationToShow)
+{
+    return (_viewerActive != nullptr) && _viewerActive->CanShowIssue_f(issue, locationToShow);
 }
 
 void cReportModuleWindow::ShowIssueInViewer(const cIssue *const issue, const cLocationsContainer *locationToShow)

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -50,6 +50,21 @@ void cReportModuleWindow::highlightRow(const cIssue *const issue, const int row)
     }
 }
 
+void cReportModuleWindow::highlightOffset(const cIssue *const issue, const int offset)
+{
+
+    if (highlighter)
+    {
+        highlighter->setOffsetToHighlight(offset);
+        textEditArea->update();
+        // Move cursor to the highlighted row and center it
+        QTextCursor cursor = textEditArea->textCursor();
+        cursor.setPosition(offset,QTextCursor::MoveAnchor);
+        textEditArea->setTextCursor(cursor);
+        textEditArea->centerCursor();
+    }
+}
+
 void cReportModuleWindow::loadFileContent(cResultContainer *const container)
 {
     QString fileToOpen;
@@ -165,6 +180,7 @@ cReportModuleWindow::cReportModuleWindow(cResultContainer *resultContainer, cons
 
     connect(_checkerWidget, &cCheckerWidget::Load, this, &cReportModuleWindow::loadFileContent);
     connect(_checkerWidget, &cCheckerWidget::ShowInputIssue, this, &cReportModuleWindow::highlightRow);
+    connect(_checkerWidget, &cCheckerWidget::ShowInputIssueOffset, this, &cReportModuleWindow::highlightOffset);
     connect(_checkerWidget, &cCheckerWidget::CanShowIssueIn3DViewer, this, &cReportModuleWindow::CheckIssueShowableInViewer);
     connect(_checkerWidget, &cCheckerWidget::ShowIssueIn3DViewer, this, &cReportModuleWindow::ShowIssueInViewer);
 

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.cpp
@@ -493,7 +493,7 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
     msgBox.setWindowTitle(this->_reportModuleName + " Error");
     msgBox.setStandardButtons(QMessageBox::Ok);
 
-    // Start viewer when we have an OpenDRIVE or an OpenSCENARIO
+    // Start viewer when we have an input file
     if (_results != nullptr && _results->HasInputFileName())
     {
         setCursor(Qt::WaitCursor);
@@ -544,7 +544,7 @@ void cReportModuleWindow::StartViewer(Viewer *viewer)
     }
     else
     {
-        msgBox.setText("Cannot start because no XODR in result. Abort.");
+        msgBox.setText("Cannot start because input file in result. Abort.");
         msgBox.exec();
     }
 }

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.h
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.h
@@ -71,11 +71,11 @@ class cReportModuleWindow : public QMainWindow
         GetName_ptr GetName_f{nullptr};
         CloseViewer_ptr CloseViewer_f{nullptr};
         GetLastErrorMessage_ptr GetLastErrorMessage_f{nullptr};
+        bool isActive{false};
         QAction *associatedAction{nullptr};
     };
 
     std::vector<std::unique_ptr<Viewer>> viewerEntries;
-    Viewer *_viewerActive{nullptr};
     void dragEnterEvent(QDragEnterEvent *event) override;
     void dropEvent(QDropEvent *event) override;
     LineHighlighter *highlighter;
@@ -95,7 +95,7 @@ class cReportModuleWindow : public QMainWindow
     virtual ~cReportModuleWindow() = default;
 
     // Loads the result container
-    void LoadResultContainer(cResultContainer *const container) const;
+    void LoadResultContainer(cResultContainer *const container);
 
   private slots:
     // Open result file
@@ -103,7 +103,7 @@ class cReportModuleWindow : public QMainWindow
     void SaveResultFile();
 
     // Starts a Viewer
-    void StartViewer(Viewer *viewer);
+    void StartViewer(Viewer *viewer, bool suppressMessages = false);
     // Checks if an issue can be shown in a viewer
     bool CheckIssueShowableInViewer(const cIssue *const issue, const cLocationsContainer *locationToShow);
     // Shows an issue in a viewer if available

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.h
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.h
@@ -53,6 +53,7 @@ class cReportModuleWindow : public QMainWindow
     typedef bool (*StartViewer_ptr)();
     typedef bool (*Initialize_ptr)(const char *);
     typedef bool (*AddIssue_ptr)(const void *);
+    typedef bool (*CanShowIssue_ptr)(const void *, const void *);
     typedef bool (*ShowIssue_ptr)(const void *, const void *);
     typedef const char *(*GetName_ptr)();
     typedef bool (*CloseViewer_ptr)();
@@ -63,6 +64,7 @@ class cReportModuleWindow : public QMainWindow
         StartViewer_ptr StartViewer_f{nullptr};
         Initialize_ptr Initialize_f{nullptr};
         AddIssue_ptr AddIssue_f{nullptr};
+        CanShowIssue_ptr CanShowIssue_f{nullptr};
         ShowIssue_ptr ShowIssue_f{nullptr};
         GetName_ptr GetName_f{nullptr};
         CloseViewer_ptr CloseViewer_f{nullptr};
@@ -98,10 +100,11 @@ class cReportModuleWindow : public QMainWindow
     void OpenResultFile();
     void SaveResultFile();
 
-    // starts the Viewer
+    // Starts a Viewer
     void StartViewer(Viewer *viewer);
-
-    // shows a XODR Issue in a viewer if available
+    // Checks if an issue can be shown in a viewer
+    bool CheckIssueShowableInViewer(const cIssue *const issue, const cLocationsContainer *locationToShow);
+    // Shows an issue in a viewer if available
     void ShowIssueInViewer(const cIssue *const issue, const cLocationsContainer *locationToShow);
 
     void onIssueToggled(bool checked);

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.h
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.h
@@ -50,6 +50,7 @@ class cReportModuleWindow : public QMainWindow
     cCheckerWidget *_checkerWidget{nullptr};
 
     // Function pointers for functions of IConnector.h
+    typedef bool (*CanSupportFormat_ptr)(const char *);
     typedef bool (*StartViewer_ptr)();
     typedef bool (*Initialize_ptr)(const char *);
     typedef bool (*AddIssue_ptr)(const void *);
@@ -61,6 +62,7 @@ class cReportModuleWindow : public QMainWindow
 
     struct Viewer
     {
+        CanSupportFormat_ptr CanSupportFormat_f{nullptr};
         StartViewer_ptr StartViewer_f{nullptr};
         Initialize_ptr Initialize_f{nullptr};
         AddIssue_ptr AddIssue_f{nullptr};

--- a/src/report_modules/report_module_gui/src/ui/c_report_module_window.h
+++ b/src/report_modules/report_module_gui/src/ui/c_report_module_window.h
@@ -127,4 +127,5 @@ class cReportModuleWindow : public QMainWindow
   public slots:
     void loadFileContent(cResultContainer *const container);
     void highlightRow(const cIssue *const issue, const int row);
+    void highlightOffset(const cIssue *const issue, const int offset);
 };


### PR DESCRIPTION
This PR extends the viewer plugin interface, while fixing some bugs and problems, to generalize the interface for arbitrary formats, and extend plugin functionality for enhanced in GUI features for new formats.

- [x] Fix life-cycle bugs in calls to CloseViewer
- [x] Fix cursor handling during StartViewer calls with errors
- [x] Remove XODR/XOSC-specific wording in UI and comments
- [x] Let plugins handle decisions of which input files they support
- [x] Let plugins handle decisions of which issues they can locate
- [x] Allow for auto-start of viewers, with support for multiple viewers being active for different input file (formats)
- [x] Implement auto-start in main GUI
- [x] Properly support offset-based FileLocations
- [ ] Allow plugins to convert file content to file view text and map issue locations to points in the file view
